### PR TITLE
Basic command line arg parsing added

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ If you have suggestions, a bug report or even want to participate to the develop
 
 There are many repository for caprice32 on GitHub:
 
-  * https://github.com/sebhz/caprice32
   * https://github.com/burzumishi/caprice32
   * https://github.com/rofl0r/caprice32
   * https://github.com/Neophile76/Caprice32
@@ -156,4 +155,4 @@ There are many repository for caprice32 on GitHub:
   * https://github.com/egrath/caprice32-mod
   * https://github.com/burzumishi/caprice32wx
 
-So why create another one ? All these repository are highly inactive but more than that, in my opinion, they took a wrong direction. Some added dependencies (wxWidget, GTK) without really adding feature. Two imported the code but did not do any update. The most promising one in my opinion is sebhz's one but the addition in it of some games images annoys me too much to contribute to it !
+So why create another one ? All these repository are highly inactive but more than that, in my opinion, they took a wrong direction. Some added dependencies (wxWidget, GTK) without really adding feature. Two imported the code but did not do any update.

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ LIBS = `sdl-config --libs` -lz `freetype-config --libs`
 
 MINGW_PATH=/usr/i686-w64-mingw32
 WINCXX	= i686-w64-mingw32-g++
-WININCS = -Isrc/ -Isrc/gui/includes -I$(MINGW_PATH)/include -I$(MINGW_PATH)/include/SDL -I$(MINGW_PATH)/include/freetype2 
+WININCS = -Isrc/ -Isrc/gui/includes -I$(MINGW_PATH)/include -I$(MINGW_PATH)/include/SDL -I$(MINGW_PATH)/include/freetype2
 WINLIBS=$(MINGW_PATH)/lib/libSDL.dll.a $(MINGW_PATH)/lib/libfreetype.dll.a $(MINGW_PATH)/lib/libz.dll.a
 
 .PHONY: all clean debug debug_flag check_deps

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -1,0 +1,61 @@
+#include <getopt.h>
+#include <iostream>
+#include <fstream>
+#include "cap32.h"
+
+const struct option long_options[] =
+{
+   {"version", no_argument, (int *)NULL, 'V'},
+   {"help",    no_argument, (int *)NULL, 'h'},
+   {(const char *)NULL, 0,  (int *)NULL, 0},
+};
+
+
+void usage(std::ostream &os, int errcode)
+{
+   os << "Usage: cap32 [options] <slotfile(s)>\n";
+   os << "\nOptions can be:\n";
+   os << "   -V/--version: outputs version and exit\n";
+   os << "   -h/--help:    shows this help\n";
+   os << "\nslotfiles is a list of files giving the content of the various CPC ports.\n";
+   os << "Supported ports files format are .dsk (disk), .cdt or .voc (tape), .cpr (cartridge), .sna (snapshot), or a .zip (archive containing one or more of the supported ports files.)\n";
+   os << "\nExample: cap32 sorcery.dsk\n";
+   os << "\nPress F1 when the emulator is running to show the in-application option menu.\n";
+   exit(errcode);
+}
+
+void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list)
+{
+   int option_index = 0;
+   int c;
+
+   optind = 0; // To please test framework, when this function is called multiple times !
+   while(1) {
+      c = getopt_long (argc, argv, "hV",
+                       long_options, &option_index);
+
+      /* Detect the end of the options. */
+      if (c == -1)
+         break;
+
+      switch (c)
+      {
+         case 'V':
+            std::cout << VERSION_STRING << "\n";
+            break;
+
+         case 'h':
+            usage(std::cout, 0);
+            break;
+
+         case '?':
+         default:
+            usage(std::cerr, 1);
+            break;
+       }
+   }
+
+   /* All remaining command line arguments will go to the slot content list */
+   slot_list.assign(argv+optind, argv+argc);
+}
+

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -1,0 +1,6 @@
+#ifndef ARGPARSE_H
+#define ARGPARSE_H
+
+void parseArguments(int, char**, std::vector<std::string>&);
+
+#endif

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -32,11 +32,10 @@
 #include "keyboard.h"
 #include "cartridge.h"
 #include "asic.h"
+#include "argparse.h"
 
 #include <errno.h>
 #include <string.h>
-
-#define VERSION_STRING "v4.3.0"
 
 #include "CapriceGui.h"
 #include "CapriceGuiView.h"
@@ -2268,7 +2267,7 @@ file_loader files_loader_list[] =
     &cartridge_load },
 };
 
-// TODO(cpitrat): Use this instead of parseArgs + code in main - remove CPC.xxxx_(path|file|zip)
+// TODO(cpitrat): Use this instead of fillSlots + code in main - remove CPC.xxxx_(path|file|zip)
 int file_load(const std::string& filepath, const DRIVE drive) {
   if (filepath.length() < 4) return ERR_FILE_UNSUPPORTED;
   int pos = filepath.length() - 4;
@@ -3189,7 +3188,7 @@ void doCleanUp (void)
 
 
 // TODO(cpitrat): refactor
-void parseArgs (int argc, const char **argv, t_CPC& CPC)
+void fillSlots (std::vector<std::string> slot_list, t_CPC& CPC)
 {
    bool have_DSKA = false;
    bool have_DSKB = false;
@@ -3197,9 +3196,9 @@ void parseArgs (int argc, const char **argv, t_CPC& CPC)
    bool have_TAP = false;
    bool have_CPR = false;
 
-   for (int i = 1; i < argc; i++) { // loop for all command line arguments
-      LOG_DEBUG("Handling arg " << argv[i]);
-      std::string fullpath = stringutils::trim(argv[i], '"'); // remove quotes if arguments quoted
+   for (unsigned int i = 0; i < slot_list.size(); i++) { // loop for all command line arguments
+      LOG_DEBUG("Handling arg " << slot_list.at(i));
+      std::string fullpath = stringutils::trim(slot_list.at(i), '"'); // remove quotes if arguments quoted
       if (fullpath.length() > 5) { // minumum for a valid filename
          int pos = fullpath.length() - 4;
          std::string dirname;
@@ -3333,6 +3332,9 @@ int cap32_main (int argc, char **argv)
    int iExitCondition;
    bool bolDone;
    SDL_Event event;
+   std::vector<std::string> slot_list;
+
+   parseArguments(argc, argv, slot_list);
 
    if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_TIMER | SDL_INIT_NOPARACHUTE) < 0) { // initialize SDL
       fprintf(stderr, "SDL_Init() failed: %s\n", SDL_GetError());
@@ -3378,7 +3380,7 @@ int cap32_main (int argc, char **argv)
    pfoDebug = fopen("./debug.txt", "wt");
    #endif
 
-   parseArgs(argc, const_cast<const char**>(argv), CPC);
+   fillSlots(slot_list, CPC);
 
    // emulator_init must be called before loading files as they require
    // pbGPBuffer to be initialized.

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -457,11 +457,6 @@ typedef struct {
    unsigned char sector_ids[2][16]; // sector IDs - indices: side, sector
 } t_disk_format;
 
-struct slotList {
-   char **names;
-   int num;
-};
-
 // cap32.cpp
 void emulator_reset(bool bolMF2Reset);
 int  emulator_init(void);

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <string>
+#include <vector>
 
 //#define DEBUG
 //#define DEBUG_CRTC
@@ -35,6 +36,8 @@
 //#define DEBUG_NO_VIDEO
 //#define DEBUG_TAPE
 //#define DEBUG_Z80
+
+#define VERSION_STRING "v4.3.0"
 
 #ifndef _MAX_PATH
  #ifdef _POSIX_PATH_MAX
@@ -454,6 +457,11 @@ typedef struct {
    unsigned char sector_ids[2][16]; // sector IDs - indices: side, sector
 } t_disk_format;
 
+struct slotList {
+   char **names;
+   int num;
+};
+
 // cap32.cpp
 void emulator_reset(bool bolMF2Reset);
 int  emulator_init(void);
@@ -498,7 +506,7 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename);
 void saveConfiguration (t_CPC &CPC, const std::string& configFilename);
 
 // Retrieve files that are passed as argument and update CPC fields so that they will be loaded properly
-void parseArgs (int argc, const char **argv, t_CPC& CPC);
+void fillSlots (std::vector<std::string> slot_list, t_CPC& CPC);
 
 int cap32_main(int argc, char **argv);
 

--- a/test/argparse.cpp
+++ b/test/argparse.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include "cap32.h"
+#include "argparse.h"
+
+TEST(ArgParseTest, parseArgsNoArg)
+{
+   const char *argv[] = {"./cap32"};
+   std::vector<std::string> slot_list;
+
+   parseArguments(1, const_cast<char **>(argv), slot_list);
+
+   ASSERT_EQ(0, slot_list.size());
+}
+
+TEST(ArgParseTest, parseArgsOneArg)
+{
+   const char *argv[] = {"./cap32", "./foo.dsk"};
+   std::vector<std::string> slot_list;
+
+   parseArguments(2, const_cast<char **>(argv), slot_list);
+
+   ASSERT_EQ(1, slot_list.size());
+   ASSERT_EQ("./foo.dsk", slot_list.at(0));
+}
+
+TEST(ArgParseTest, parseArgsSeveralArgs)
+{
+   const char *argv[] = {"./cap32", "./foo.dsk", "bar.zip", "0", "__"};
+   std::vector<std::string> slot_list;
+
+   parseArguments(5, const_cast<char **>(argv), slot_list);
+
+   ASSERT_EQ(4, slot_list.size());
+   for (int i=1; i < 5; i++)
+	   ASSERT_EQ(argv[i], slot_list.at(i-1));
+}
+

--- a/test/cap32.cpp
+++ b/test/cap32.cpp
@@ -2,12 +2,12 @@
 
 #include "cap32.h"
 
-TEST(Cap32Test, parseArgsNoArg)
+TEST(Cap32Test, fillSlotsNoArg)
 {
-  const char *argv[] = { "./cap32" };
+  std::vector<std::string> slot_list;
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("", CPC.cart_path);
   ASSERT_EQ("", CPC.cart_file);
@@ -21,12 +21,12 @@ TEST(Cap32Test, parseArgsNoArg)
   ASSERT_EQ("", CPC.snap_file);
 }
 
-TEST(Cap32Test, parseArgsOneLocalDskFile)
+TEST(Cap32Test, fillSlotsOneLocalDskFile)
 {
-  const char *argv[] = { "./cap32", "./test.dsk" };
+  std::vector<std::string> slot_list = { "./test.dsk"};
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("", CPC.cart_path);
   ASSERT_EQ("", CPC.cart_file);
@@ -41,12 +41,12 @@ TEST(Cap32Test, parseArgsOneLocalDskFile)
   ASSERT_EQ("", CPC.snap_file);
 }
 
-TEST(Cap32Test, parseArgsTwoDskFiles)
+TEST(Cap32Test, fillSlotsTwoDskFiles)
 {
-  const char *argv[] = { "./cap32", "/tmp/foo.dsk", "/var/bar.dsk" };
+  std::vector<std::string> slot_list = { "/tmp/foo.dsk", "/var/bar.dsk"};
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("", CPC.cart_path);
   ASSERT_EQ("", CPC.cart_file);
@@ -62,12 +62,12 @@ TEST(Cap32Test, parseArgsTwoDskFiles)
   ASSERT_EQ("", CPC.snap_file);
 }
 
-TEST(Cap32Test, parseArgsOneLocalCdtFile)
+TEST(Cap32Test, fillSlotsOneLocalCdtFile)
 {
-  const char *argv[] = { "./cap32", "./test.cdt" };
+  std::vector<std::string> slot_list = { "./test.cdt"};
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("", CPC.cart_path);
   ASSERT_EQ("", CPC.cart_file);
@@ -82,12 +82,12 @@ TEST(Cap32Test, parseArgsOneLocalCdtFile)
   ASSERT_EQ("", CPC.snap_file);
 }
 
-TEST(Cap32Test, parseArgsOneLocalVocFile)
+TEST(Cap32Test, fillSlotsOneLocalVocFile)
 {
-  const char *argv[] = { "./cap32", "./test.voc" };
+  std::vector<std::string> slot_list = { "./test.voc"};
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("", CPC.cart_path);
   ASSERT_EQ("", CPC.cart_file);
@@ -102,12 +102,12 @@ TEST(Cap32Test, parseArgsOneLocalVocFile)
   ASSERT_EQ("", CPC.snap_file);
 }
 
-TEST(Cap32Test, parseArgsOneLocalSnaFile)
+TEST(Cap32Test, fillSlotsOneLocalSnaFile)
 {
-  const char *argv[] = { "./cap32", "./test.sna" };
+  std::vector<std::string> slot_list = { "./test.sna"};
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("", CPC.cart_path);
   ASSERT_EQ("", CPC.cart_file);
@@ -122,12 +122,12 @@ TEST(Cap32Test, parseArgsOneLocalSnaFile)
   ASSERT_EQ(0, CPC.snap_zip);
 }
 
-TEST(Cap32Test, parseArgsOneCprFile)
+TEST(Cap32Test, fillSlotsOneCprFile)
 {
-  const char *argv[] = { "./cap32", "./test.cpr" };
+  std::vector<std::string> slot_list = { "./test.cpr"};
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("./", CPC.cart_path);
   ASSERT_EQ("test.cpr", CPC.cart_file);
@@ -142,12 +142,12 @@ TEST(Cap32Test, parseArgsOneCprFile)
   ASSERT_EQ("", CPC.snap_file);
 }
 
-TEST(Cap32Test, parseArgsOneZippedCprFile)
+TEST(Cap32Test, fillSlotsOneZippedCprFile)
 {
-  const char *argv[] = { "./cap32", "test/cartridge/testplus.zip" };
+  std::vector<std::string> slot_list = { "test/cartridge/testplus.zip"};
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("test/cartridge/testplus.zip", CPC.cart_path);
   ASSERT_EQ("testplus.cpr", CPC.cart_file);
@@ -162,12 +162,12 @@ TEST(Cap32Test, parseArgsOneZippedCprFile)
   ASSERT_EQ("", CPC.snap_file);
 }
 
-TEST(Cap32Test, parseArgsOneFileOfEachKind)
+TEST(Cap32Test, fillSlotsOneFileOfEachKind)
 {
-  const char *argv[] = { "./cap32", "/tmp/foo.dsk", "/var/bar.cdt", "/usr/test.sna", "/home/cart.cpr" };
+  std::vector<std::string> slot_list = { "/tmp/foo.dsk", "/var/bar.cdt", "/usr/test.sna", "/home/cart.cpr" };
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("/home/", CPC.cart_path);
   ASSERT_EQ("cart.cpr", CPC.cart_file);
@@ -184,12 +184,12 @@ TEST(Cap32Test, parseArgsOneFileOfEachKind)
   ASSERT_EQ(0, CPC.snap_zip);
 }
 
-TEST(Cap32Test, parseArgsManyFilesOfEachKind)
+TEST(Cap32Test, fillSlotsManyFilesOfEachKind)
 {
-  const char *argv[] = { "./cap32", "rom/system.cpr", "/tmp/foo.dsk", "/var/test.dsk", "/tmp/other.dsk", "/var/bar.cdt", "/tmp/test.voc", "/usr/test.sna", "/tmp/other.sna", "test/test.cpr" };
+  std::vector<std::string> slot_list = { "rom/system.cpr", "/tmp/foo.dsk", "/var/test.dsk", "/tmp/other.dsk", "/var/bar.cdt", "/tmp/test.voc", "/usr/test.sna", "/tmp/other.sna", "test/test.cpr" };
   t_CPC CPC;
 
-  parseArgs(sizeof(argv)/sizeof(char*), argv, CPC);
+  fillSlots(slot_list, CPC);
 
   ASSERT_EQ("rom/", CPC.cart_path);
   ASSERT_EQ("system.cpr", CPC.cart_file);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv) 
+int main(int argc, char **argv)
 {
 	::testing::InitGoogleTest(&argc, argv);
 	return RUN_ALL_TESTS();


### PR DESCRIPTION
argc/argv fully handled in their own module. Rest of the code mostly unchanged. Basic tests added for the new arg parsing module.
For now this only displays a very basic help as well as the version name.

If needed be we can reuse the argparse file to overwrite some of the options in cap32.cfg, but this would require reordering cap32.cfg parsing. This is probably overkill - except maybe to modify the path to cap32.cfg, for test and debug purpose.
