### PR TITLE
Commented out (most of) cap32.cfg file

### DIFF
--- a/cap32.cfg
+++ b/cap32.cfg
@@ -19,7 +19,7 @@ ram_size=128
 #   clock speed (MHz)
 speed=4
 # auto_pause
-#   seems unused for now
+#   Not implemented: pause emulator when it looses focus
 auto_pause=1
 # printer
 #   0: No printer present
@@ -29,9 +29,10 @@ printer=0
 #   0: No multiface 2 hardware present
 #   1: Multiface 2 hardware present
 mf2=1
-# keyboard
-#   0: No keyboard present
-#   1: Keyboard present
+# CPC keyboard layout
+#   0: English layout
+#   1: French layout
+#   2: Spanish layout
 keyboard=1
 # joysticks
 #   0: No joystick present
@@ -80,10 +81,8 @@ scr_oglfilter=1
 #   Integer number of emulated scanlines between 0 (no scanline) and 100
 #   Useful only if openGL scaling is used
 scr_oglscanlines=30
-# scr_vsync
 # scr_led
-#   Seem unused for now
-scr_vsync=0
+#   Not implemented: display floppy led on screen
 scr_led=1
 # scr_fps
 #   0: Do not show fps
@@ -98,6 +97,7 @@ scr_tube=0
 #   Integer number ranging from 5 (dark) to 10 (light)
 scr_intensity=10
 # scr_remanency
+#   OpenGL only
 #   0: No screen remanency emulated
 #   1: Screen remanency emulated
 scr_remanency=0
@@ -138,6 +138,7 @@ pp_device=0
 
 [control]
 # kbd_layout
+#   Host keyboard layout
 #   0: English
 #   1: French
 #   2: Spanish
@@ -171,9 +172,6 @@ fmt07=
 # printer_file
 #   Path to output printer stream
 printer_file=./printer.dat
-# sdump_file
-#   Unused for now
-sdump_file=./screen.png
 
 [rom]
 rom_path=./rom

--- a/cap32.cfg
+++ b/cap32.cfg
@@ -1,40 +1,148 @@
+#
+# Caprice32 configuration file.
+#
 [system]
+# model
+#   0: CPC464
+#   1: CPC664
+#   2: CPC6128
+#   3: CPC6128+
 model=2
+# jumpers
+#   Hardware CPC jumpers. Specify screen refresh rate and manufacturer
+#   Edit at your own risk
 jumpers=30
+# ram_size
+#   CPC physical RAM size in kB
 ram_size=128
+# speed
+#   clock speed (MHz)
 speed=4
+# auto_pause
+#   seems unused for now
 auto_pause=1
+# printer
+#   0: No printer present
+#   1: Printer present
 printer=0
+# mf2
+#   0: No multiface 2 hardware present
+#   1: Multiface 2 hardware present
 mf2=1
+# keyboard
+#   0: No keyboard present
+#   1: Keyboard present
 keyboard=1
+# joysticks
+#   0: No joystick present
+#   1: Joystick present
 joysticks=1
+# joystick emulation
+#   0: Use host joystick(s)
+#   1: Emulate host joystick #0 with arrows + X + Z keys
 joystick_emulation=0
+# joystick_menu_button
+#   host joystick button number to invoke emulator menu
 joystick_menu_button=9
+# joystick_vkeyboard_menu_button
+#   host joystick button number to invoke virtual keyboard
 joystick_vkeyboard_button=10
+# resources_path
+#   path to resources (menu images...)
 resources_path=./resources
+
 [video]
+# src_width/height/bpp
+#   Dimension and bit depth of the emulator window
 scr_width=800
 scr_height=600
 scr_bpp=32
+# scr_style
+#   0: Half size with hardware flip
+#   1: Double size with hardware flip
+#   2: Half size
+#   3: Double size
+#   4: Super eagle
+#   5: Scale2x
+#   6: Advanced Scale2x
+#   7: TV 2x
+#   8: Software bilinear
+#   9: Software bicubic
+#  10: Dot matrix
+#  11: OpenGL scaling
 scr_style=1
+# scr_oglfilter
+#   0: OpenGL filter inactive
+#   1: OpenGL filter active
+#   Useful only if openGL scaling is used
 scr_oglfilter=1
+# scr_oglscanlines
+#   Integer number of emulated scanlines between 0 (no scanline) and 100
+#   Useful only if openGL scaling is used
 scr_oglscanlines=30
+# scr_vsync
+# scr_led
+#   Seem unused for now
 scr_vsync=0
 scr_led=1
+# scr_fps
+#   0: Do not show fps
+#   1: Show fps
 scr_fps=1
+# scr_tube
+#   0: Color display
+#   1: Monochrome display
 scr_tube=0
+# scr_intensity
+#   Screen cathodic tube intensity
+#   Integer number ranging from 5 (dark) to 10 (light)
 scr_intensity=10
+# scr_remanency
+#   0: No screen remanency emulated
+#   1: Screen remanency emulated
 scr_remanency=0
+# scr_window
+#   0: Fullscreen mode
+#   1: Windowed mode
 scr_window=1
+
 [sound]
+# enabled
+#   0: sound emulation disabled
+#   1: sound emulation enabled
 enabled=1
+# playback_rate
+#   Audio playback sampling rate
+#   0: 11.025 kHz
+#   1: 22.050 kHz
+#   2: 44.100 kHz
+#   3: 48.000 kHz
+#   4: 96.000 kHz
 playback_rate=2
+# bits
+#   0:  8 bits per sample audio
+#   1: 16 bits per sample audio
 bits=1
+# stereo
+#   0: Use mono sound
+#   1: Use stereo sound
 stereo=1
+# volume
+#   Audio volume
+#   Integer number ranging from 0 (silent) to 100 (very loud)
 volume=80
+# pp_device
+#   0: No Digiblaster/soundplayer device attached to the printer port
+#   1: Digiblaster/soundplayer device attached to the printer port
 pp_device=0
+
 [control]
+# kbd_layout
+#   0: English
+#   1: French
+#   2: Spanish
 kbd_layout=1
+
 [file]
 max_track_size=5990
 cart_path=./rom/
@@ -60,8 +168,13 @@ fmt04=
 fmt05=
 fmt06=
 fmt07=
+# printer_file
+#   Path to output printer stream
 printer_file=./printer.dat
+# sdump_file
+#   Unused for now
 sdump_file=./screen.png
+
 [rom]
 rom_path=./rom
 slot00=


### PR DESCRIPTION
Still more effort to document the emulator functionalities. What was not obvious I derived by looking at the code. It looks like at least two parameters are not used at all (scr_vsync and scr_led), but I might have missed something.