### PR TITLE
Minor improvements to CL option parsing

### DIFF
--- a/doc/man.html
+++ b/doc/man.html
@@ -211,6 +211,6 @@ $HOME/.cap32.cfg
 This document was created by
 <A HREF="/cgi-bin/man/man2html">man2html</A>,
 using the manual pages.<BR>
-Time: 15:36:19 GMT, March 14, 2017
+Time: 20:14:46 GMT, March 13, 2017
 </BODY>
 </HTML>

--- a/doc/man.html
+++ b/doc/man.html
@@ -145,6 +145,8 @@ use FILE as the emulator configuration file.
 display short help and exits
 <DT><B>-V</B>, <B>--version</B><DD>
 display Caprice32 version and exits
+<DT><B>-v</B>, <B>--verbose</B><DD>
+be talkative about what hte emulator is doing (mostly for debug builds)
 <P>
 </DL>
 <A NAME="lbAF">&nbsp;</A>
@@ -211,6 +213,6 @@ $HOME/.cap32.cfg
 This document was created by
 <A HREF="/cgi-bin/man/man2html">man2html</A>,
 using the manual pages.<BR>
-Time: 20:14:46 GMT, March 13, 2017
+Time: 10:22:28 GMT, March 15, 2017
 </BODY>
 </HTML>

--- a/doc/man.html
+++ b/doc/man.html
@@ -122,7 +122,7 @@ Caprice32 can also be controlled completely from the joystick. The configuration
 
 <B>Keyboard mapping</B>
 <DL COMPACT><DT><DD>
-Caprice32 supports CPC English, French and Spanish keyboard layouts. The CPC keyboard layout is defined in the configuration file by the <B>keyboard</B> entry (0: English, 1: French, 2: Spanish). Additionally one can define the layout of the host keyboard in the configuration file, using <B>kbd_layout</B> entry. <B>kbd_layout</B> supports the same three values as <B>keyboard</B> and should remap properly the most current keys found on English (US and UK), French and Spanish keyboards.
+Caprice32 supports CPC English, French and Spanish keyboard layouts. The CPC keyboard layout is defined in the configuration file by the <B>keyboard</B> entry (0: English, 1: French, 2: Spanish). Additionally one can define the layout of the host keyboard in the configuration file, using <B>kbd_layout</B> entry. <B>kbd_layout</B> supports the same three values as <B>keyboard</B> and should remap properly most keys found on English (US and UK), French and Spanish keyboards.
 </DL>
 
 <P>
@@ -146,7 +146,7 @@ display short help and exits
 <DT><B>-V</B>, <B>--version</B><DD>
 display Caprice32 version and exits
 <DT><B>-v</B>, <B>--verbose</B><DD>
-be talkative about what hte emulator is doing (mostly for debug builds)
+be talkative about what the emulator is doing (mostly for debug builds)
 <P>
 </DL>
 <A NAME="lbAF">&nbsp;</A>
@@ -213,6 +213,6 @@ $HOME/.cap32.cfg
 This document was created by
 <A HREF="/cgi-bin/man/man2html">man2html</A>,
 using the manual pages.<BR>
-Time: 10:22:28 GMT, March 15, 2017
+Time: 13:28:03 GMT, March 15, 2017
 </BODY>
 </HTML>

--- a/doc/man6/cap32.6
+++ b/doc/man6/cap32.6
@@ -78,7 +78,7 @@ Caprice32 can also be controlled completely from the joystick. The configuration
 .PP
 \fBKeyboard mapping\fR
 .RS
-Caprice32 supports CPC English, French and Spanish keyboard layouts. The CPC keyboard layout is defined in the configuration file by the \fBkeyboard\fR entry (0: English, 1: French, 2: Spanish). Additionally one can define the layout of the host keyboard in the configuration file, using \fBkbd_layout\fR entry. \fBkbd_layout\fR supports the same three values as \fBkeyboard\fR and should remap properly the most current keys found on English (US and UK), French and Spanish keyboards.
+Caprice32 supports CPC English, French and Spanish keyboard layouts. The CPC keyboard layout is defined in the configuration file by the \fBkeyboard\fR entry (0: English, 1: French, 2: Spanish). Additionally one can define the layout of the host keyboard in the configuration file, using \fBkbd_layout\fR entry. \fBkbd_layout\fR supports the same three values as \fBkeyboard\fR and should remap properly most keys found on English (US and UK), French and Spanish keyboards.
 .RE
 
 
@@ -99,6 +99,9 @@ display short help and exits
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 display Caprice32 version and exits
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+be talkative about what the emulator is doing (mostly for debug builds)
 
 .SH EXAMPLES
 .PP

--- a/makefile
+++ b/makefile
@@ -74,6 +74,8 @@ else
 all: insert_hash check_deps cap32
 endif
 
+src/argparse.c: insert_hash
+
 $(MAIN): main.cpp src/cap32.h
 	@$(CXX) -c $(BUILD_FLAGS) $(CFLAGS) -o $(MAIN) main.cpp
 

--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@
 # use "make DEBUG=TRUE" to build a debug executable
 
 LAST_BUILD_IN_DEBUG=$(shell [ -e .debug ] && echo 1 || echo 0)
+GIT_HASH=$(shell git rev-parse --verify HEAD)
 
 OBJDIR:=obj
 SRCDIR:=src
@@ -33,7 +34,7 @@ WINCXX	= i686-w64-mingw32-g++
 WININCS = -Isrc/ -Isrc/gui/includes -I$(MINGW_PATH)/include -I$(MINGW_PATH)/include/SDL -I$(MINGW_PATH)/include/freetype2
 WINLIBS=$(MINGW_PATH)/lib/libSDL.dll.a $(MINGW_PATH)/lib/libfreetype.dll.a $(MINGW_PATH)/lib/libz.dll.a
 
-.PHONY: all clean debug debug_flag check_deps
+.PHONY: all clean debug debug_flag check_deps insert_hash
 
 ifndef CXX
 CXX	= g++
@@ -68,9 +69,9 @@ endif
 
 ifdef DEBUG
 BUILD_FLAGS=$(DEBUG_FLAGS)
-all: check_deps debug
+all: insert_hash check_deps debug
 else
-all: check_deps cap32
+all: insert_hash check_deps cap32
 endif
 
 $(MAIN): main.cpp src/cap32.h
@@ -102,6 +103,10 @@ check_deps:
 	@sdl-config --cflags >/dev/null 2>&1 || (echo "Error: missing dependency libsdl-1.2. Try installing libsdl 1.2 development package (e.g: libsdl1.2-dev)" && false)
 	@freetype-config --cflags >/dev/null 2>&1 || (echo "Error: missing dependency libfreetype. Try installing libfreetype development package (e.g: libfreetype6-dev)" && false)
 	@pkg-config --cflags zlib >/dev/null 2>&1 || (echo "Error: missing dependency zlib. Try installing zlib development package (e.g: zlib-devel)" && false)
+
+# This might fail on non GNU systems as sed -i in GNU sed only
+insert_hash:
+	@sed -i 's/commit_hash = ".*"/commit_hash = "$(GIT_HASH)"/' src/argparse.cpp
 
 tags:
 	@ctags -R . || echo -e "!!!!!!!!!!!\n!! Warning: ctags not found - if you are a developer, you might want to install it.\n!!!!!!!!!!!"

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -64,6 +64,17 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
 
          case 'V':
             std::cout << "Caprice32 " << VERSION_STRING << "\n";
+            std::cout << "Compiled with:"
+#ifdef HAVE_GL
+                      << " HAVE_GL"
+#endif
+#ifdef HAVE_PNG
+                      << " HAVE_PNG"
+#endif
+#ifdef DEBUG
+                      << " DEBUG"
+#endif
+                      << "\n";
             exit(0);
             break;
 

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -6,6 +6,8 @@
 #include "stringutils.h"
 
 extern bool log_verbose;
+const std::string commit_hash = "1054dbd09e86016cd931769071c3f0738f381cb7";
+
 const struct option long_options[] =
 {
    {"cfg_file", required_argument, nullptr, 'c'},
@@ -56,7 +58,6 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
 
       switch (c)
       {
-
          case 'c':
             args.cfgFilePath = optarg;
             break;
@@ -82,6 +83,8 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
                       << " DEBUG"
 #endif
                       << "\n";
+            if (!commit_hash.empty())
+               std::cout << "From source hash: " << commit_hash << "\n";
             exit(0);
             break;
 

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -6,7 +6,7 @@
 #include "stringutils.h"
 
 extern bool log_verbose;
-const std::string commit_hash = "1054dbd09e86016cd931769071c3f0738f381cb7";
+std::string commit_hash = "992241d590b725108cb439766a8820c4a32f775f";
 
 const struct option long_options[] =
 {
@@ -71,7 +71,7 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
             break;
 
          case 'V':
-            std::cout << "Caprice32 " << VERSION_STRING << "\n";
+            std::cout << "Caprice32 " << VERSION_STRING << (commit_hash.empty()?"\n":"-"+commit_hash+"\n");
             std::cout << "Compiled with:"
 #ifdef HAVE_GL
                       << " HAVE_GL"
@@ -83,8 +83,6 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
                       << " DEBUG"
 #endif
                       << "\n";
-            if (!commit_hash.empty())
-               std::cout << "From source hash: " << commit_hash << "\n";
             exit(0);
             break;
 

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -5,11 +5,13 @@
 #include "argparse.h"
 #include "stringutils.h"
 
+extern bool log_verbose;
 const struct option long_options[] =
 {
    {"cfg_file", required_argument, nullptr, 'c'},
    {"version",  no_argument, nullptr, 'V'},
    {"help",     no_argument, nullptr, 'h'},
+   {"verbose",  no_argument, nullptr, 'v'},
    {nullptr, 0, nullptr, 0},
 };
 
@@ -29,6 +31,7 @@ void usage(std::ostream &os, char *progPath, int errcode)
    os << "   -c/--cfg_file=<file>:   use <file> as the emulator configuration file instead of the default.\n";
    os << "   -h/--help:              shows this help\n";
    os << "   -V/--version:           outputs version and exit\n";
+   os << "   -v/--verbose:           be talkative\n";
    os << "\nslotfiles is an optional list of files giving the content of the various CPC ports.\n";
    os << "Ports files are identified by their extension. Supported formats are .dsk (disk), .cdt or .voc (tape), .cpr (cartridge), .sna (snapshot), or .zip (archive containing one or more of the supported ports files).\n";
    os << "\nExample: " << progname << " sorcery.dsk\n";
@@ -44,7 +47,7 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
 
    optind = 0; // To please test framework, when this function is called multiple times !
    while(1) {
-      c = getopt_long (argc, argv, "c:hV",
+      c = getopt_long (argc, argv, "c:hvV",
                        long_options, &option_index);
 
       /* Detect the end of the options. */
@@ -60,6 +63,10 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
 
          case 'h':
             usage(std::cout, argv[0], 0);
+            break;
+
+         case 'v':
+            log_verbose = true;
             break;
 
          case 'V':

--- a/src/gui/src/CapriceAbout.cpp
+++ b/src/gui/src/CapriceAbout.cpp
@@ -6,6 +6,7 @@
 
 // CPC emulation properties, defined in cap32.h:
 extern t_CPC CPC;
+extern std::string commit_hash;
 
 namespace wGui {
 
@@ -14,7 +15,7 @@ CapriceAbout::CapriceAbout(const CRect& WindowRect, CWindow* pParent, CFontEngin
 {
   SetModal(true);
 	// Override here: specify position of label ourselves:
-	m_pMessageLabel = new CLabel(CPoint(5, 70), this, "Version 4.3.0");
+	m_pMessageLabel = new CLabel(CPoint(5, 70), this, VERSION_STRING + (commit_hash.empty()?"":"-"+commit_hash.substr(0, 16)));
 	m_pMessageLabel = new CLabel(CPoint(5, 90), this, "F1 - Menu / Pause");
 	m_pMessageLabel = new CLabel(CPoint(5, 100), this, "F2 - Fullscreen");
 	m_pMessageLabel = new CLabel(CPoint(5, 110), this, "F3 - Save screenshot");


### PR DESCRIPTION
- add --verbose option to control log verbosity from command line,
- now display compilation flags and git commit id from which the executable was compiled in the --version output.