### PR TITLE
Native MS Windows makefile fix

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,6 +15,8 @@
 
 LAST_BUILD_IN_DEBUG = $(shell [ -e .debug ] && echo 1 || echo 0)
 GIT_HASH = $(shell git rev-parse --verify HEAD)
+# If compiling under native windows, set WINE to ""
+WINE = wine
 
 ifndef ARCH
 ARCH = linux
@@ -198,8 +200,9 @@ $(TEST_TARGET): $(OBJECTS) $(TEST_OBJECTS) $(OBJDIR)/$(GTEST_DIR)/src/gtest-all.
 ifeq ($(PLATFORM),windows)
 unit_test: $(TEST_TARGET)
 	cp $(TEST_TARGET) $(ARCHIVE)/
+	rm -fr $(ARCHIVE)/test
 	ln -s -f ../../test $(ARCHIVE)/test
-	cd $(ARCHIVE) && wine ./$(TEST_TARGET) --gtest_shuffle
+	cd $(ARCHIVE) && $(WINE) ./$(TEST_TARGET) --gtest_shuffle
 else
 unit_test: $(TEST_TARGET)
 	./$(TEST_TARGET) --gtest_shuffle


### PR DESCRIPTION
    * Added WINE variable to be able to launch testrunner under native
      MS Windows with 'make WINE= unit_test'
    * Somehow symlinking seemed to fail if target was already present.
      So debug build crashed if no make clean was done before.
      Explicitly remove the symlink.