### PR TITLE
Timing fix

### DIFF
--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -1566,13 +1566,18 @@ void input_swap_joy (void)
    }
 }
 
-// Recalculate emulation speed (to verify, seems to work reasonably well)
-void update_cpc_speed(void)
+void update_timings(void)
 {
-   dwTicksOffset = static_cast<int>(20.0 / ((CPC.speed * 25) / 100.0));
+   dwTicksOffset = static_cast<int>(FRAME_PERIOD_MS / (CPC.speed/CPC_BASE_FREQUENCY_MHZ));
    dwTicksTarget = SDL_GetTicks();
    dwTicksTargetFPS = dwTicksTarget;
    dwTicksTarget += dwTicksOffset;
+}
+
+// Recalculate emulation speed (to verify, seems to work reasonably well)
+void update_cpc_speed(void)
+{
+   update_timings();
    InitAY();
 }
 
@@ -2017,12 +2022,7 @@ int cap32_main (int argc, char **argv)
 
 // ----------------------------------------------------------------------------
 
-   // TODO: deduplicate this and update_cpc_speed
-   dwTicksOffset = static_cast<int>(FRAME_PERIOD_MS / (CPC.speed/CPC_BASE_FREQUENCY_MHZ));
-   dwTicksTarget = SDL_GetTicks();
-   dwTicksTargetFPS = dwTicksTarget;
-   dwTicksTarget += dwTicksOffset;
-
+   update_timings();
    audio_resume();
 
    iExitCondition = EC_FRAME_COMPLETE;

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -2018,7 +2018,7 @@ int cap32_main (int argc, char **argv)
 // ----------------------------------------------------------------------------
 
    // TODO: deduplicate this and update_cpc_speed
-   dwTicksOffset = static_cast<int>(20.0 / (CPC.speed * 25) / 100.0);
+   dwTicksOffset = static_cast<int>(20.0 / (CPC.speed/CPC_BASE_FREQUENCY_MHZ));
    dwTicksTarget = SDL_GetTicks();
    dwTicksTargetFPS = dwTicksTarget;
    dwTicksTarget += dwTicksOffset;

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -2018,7 +2018,7 @@ int cap32_main (int argc, char **argv)
 // ----------------------------------------------------------------------------
 
    // TODO: deduplicate this and update_cpc_speed
-   dwTicksOffset = static_cast<int>(20.0 / (CPC.speed/CPC_BASE_FREQUENCY_MHZ));
+   dwTicksOffset = static_cast<int>(FRAME_PERIOD_MS / (CPC.speed/CPC_BASE_FREQUENCY_MHZ));
    dwTicksTarget = SDL_GetTicks();
    dwTicksTargetFPS = dwTicksTarget;
    dwTicksTarget += dwTicksOffset;

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -48,6 +48,7 @@
 #endif
 
 #define CYCLE_COUNT_INIT 80000 // 4MHz divided by 50Hz = number of CPU cycles per frame
+#define CPC_BASE_FREQUENCY_MHZ 4.0
 
 #define CPC_SCR_WIDTH 1024 // max width
 #define CPC_SCR_HEIGHT 312 // max height

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -47,8 +47,9 @@
  #endif
 #endif
 
-#define CYCLE_COUNT_INIT 80000 // 4MHz divided by 50Hz = number of CPU cycles per frame
-#define CPC_BASE_FREQUENCY_MHZ 4.0
+#define CPC_BASE_FREQUENCY_MHZ  4.0
+#define FRAME_PERIOD_MS        20.0
+#define CYCLE_COUNT_INIT (CPC_BASE_FREQUENCY_MHZ*FRAME_PERIOD_MS*1000)
 
 #define CPC_SCR_WIDTH 1024 // max width
 #define CPC_SCR_HEIGHT 312 // max height


### PR DESCRIPTION
A funny bug in the offset computation made it so we were actually timed by the sound buffer. This patch fixes this - or so I hope :-)
See issue #72.