### PR TITLE
Limit CPU usage

### DIFF
--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -1233,7 +1233,7 @@ int audio_init ()
    desired->freq = freq_table[CPC.snd_playback_rate];
    desired->format = CPC.snd_bits ? AUDIO_S16LSB : AUDIO_S8;
    desired->channels = CPC.snd_stereo+1;
-   desired->samples = audio_align_samples(desired->freq / 50); // desired is 20ms at the given frequency
+   desired->samples = audio_align_samples(desired->freq * FRAME_PERIOD_MS / 1000);
    desired->callback = audio_update;
    desired->userdata = nullptr;
 
@@ -2226,9 +2226,9 @@ int cap32_main (int argc, char **argv)
 
          if (CPC.limit_speed) { // limit to original CPC speed?
             if (CPC.snd_enabled) {
-               if (iExitCondition == EC_SOUND_BUFFER) {
-                  if (!dwSndBufferCopied) { // limit speed ?
-                     continue; // delay emulation
+               if (iExitCondition == EC_SOUND_BUFFER) { // Emulation filled a sound buffer.
+                  if (!dwSndBufferCopied) {
+                     continue; // delay emulation until our audio callback copied and played the buffer
                   }
                   dwSndBufferCopied = 0;
                }

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -2263,7 +2263,7 @@ int cap32_main (int argc, char **argv)
                print(static_cast<dword *>(back_surface->pixels) + CPC.scr_line_offs, osd_message.c_str(), true);
             } else if (CPC.scr_fps) {
                char chStr[15];
-               sprintf(chStr, "%3dFPS %3d%%", static_cast<int>(dwFPS), static_cast<int>(dwFPS) * 100 / 50);
+               sprintf(chStr, "%3dFPS %3d%%", static_cast<int>(dwFPS), static_cast<int>(dwFPS) * 100 / (1000 / static_cast<int>(FRAME_PERIOD_MS)));
                print(static_cast<dword *>(back_surface->pixels) + CPC.scr_line_offs, chStr, true); // display the frames per second counter
             }
             asic_draw_sprites();


### PR DESCRIPTION
Partially addresses issue #74.
Sleep when we are paused or when we have nothing to do. To keep the UI responsive we sleep by slices of 1 ms.
The sync path when audio is enabled and we are sync'ed by it was not changed (need to fully understand the constraints here). So this patch is partial only, but it brings a nice CPU load improvement when audio is disabled or emulator is paused. No impact seen on the overall responsiveness (tried on a couple of games).