### PR TITLE
Made extension matching in the load/save dialog case-insensitive.

### DIFF
--- a/src/gui/src/CapriceLoadSave.cpp
+++ b/src/gui/src/CapriceLoadSave.cpp
@@ -288,7 +288,7 @@ bool CapriceLoadSave::MatchCurrentFileSpec(const char* filename)
   for(const auto &ext : m_fileSpec) {
     size_t lenFileName = strlen(filename);
     if (lenFileName < ext.size()) continue;
-    if (strncmp(&(filename[lenFileName-ext.size()]), ext.c_str(), ext.size()) == 0) {
+    if (strncasecmp(&(filename[lenFileName-ext.size()]), ext.c_str(), ext.size()) == 0) {
       return true;
     }
   }

--- a/test/CapriceLoadSave.cpp
+++ b/test/CapriceLoadSave.cpp
@@ -66,3 +66,12 @@ TEST_F(CapriceLoadSaveTest, MatchCurrentFileSpecSupportsVariousExtensionSizes)
   ASSERT_TRUE(cls->MatchCurrentFileSpec("test.nodot"));
   ASSERT_FALSE(cls->MatchCurrentFileSpec("dot"));
 }
+
+TEST_F(CapriceLoadSaveTest, MatchCurrentFileSpecIsCaseInsensitive) {
+  std::list<std::string> fileSpec = { ".dsk" };
+  SetFileSpec(fileSpec);
+
+  ASSERT_TRUE(cls->MatchCurrentFileSpec("test.dsk"));
+  ASSERT_TRUE(cls->MatchCurrentFileSpec("TEST.DSK"));
+  ASSERT_TRUE(cls->MatchCurrentFileSpec("test.DsK"));
+}


### PR DESCRIPTION
Disk images are often generated on Windows computers, and Windows
doesn't care about case sensitiveness, so you're as likely to end up
with BARBARIAN.DSK as barbarian.dsk. With this change, Caprice32 finds
the disk image in both cases.