### PR TITLE
Made directory listings case-insensitive.

### DIFF
--- a/src/gui/src/CapriceLoadSave.cpp
+++ b/src/gui/src/CapriceLoadSave.cpp
@@ -5,6 +5,7 @@
 #include "cap32.h"
 #include "slotshandler.h"
 #include "cartridge.h"
+#include "stringutils.h"
 
 #include <iostream>
 #include <sys/types.h>
@@ -28,7 +29,7 @@ extern t_drive driveB;
 namespace wGui {
 
 CapriceLoadSave::CapriceLoadSave(const CRect& WindowRect, CWindow* pParent, CFontEngine* pFontEngine) :
-	CFrame(WindowRect, pParent, pFontEngine, "Load / Save", false)
+  CFrame(WindowRect, pParent, pFontEngine, "Load / Save", false)
 {
   SetModal(true);
   // Make this window listen to incoming CTRL_VALUECHANGE messages (used for updating drop down values)
@@ -90,12 +91,12 @@ CapriceLoadSave::~CapriceLoadSave() = default;
 
 bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
 {
-	bool bHandled = false;
+  bool bHandled = false;
 
-	if (pMessage)
-	{
-		switch(pMessage->MessageType())
-		{
+  if (pMessage)
+  {
+    switch(pMessage->MessageType())
+    {
       case CMessage::CTRL_SINGLELCLICK:
         {
           if (pMessage->Destination() == this)
@@ -247,7 +248,7 @@ bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
           } else {
             m_pFileNameValue->SetWindowText(fn);
           }
-				}
+        }
         break;
 
       default :
@@ -257,7 +258,7 @@ bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
   if (!bHandled) {
     bHandled = CFrame::HandleMessage(pMessage);
   }
-	return bHandled;
+  return bHandled;
 }
 
 std::string CapriceLoadSave::simplifyDirPath(std::string path)
@@ -325,8 +326,8 @@ void CapriceLoadSave::UpdateFilesList()
     if(closedir(dp) != 0) {
       std::cerr << "Could not close directory: " << strerror(errno) << std::endl;
     }
-    std::sort(directories.begin(), directories.end());
-    std::sort(files.begin(), files.end());
+    std::sort(directories.begin(), directories.end(), stringutils::caseInsensitiveCompare);
+    std::sort(files.begin(), files.end(), stringutils::caseInsensitiveCompare);
     for(const auto &directory : directories) {
       m_pFilesList->AddItem(SListItem(directory));
     }

--- a/src/stringutils.cpp
+++ b/src/stringutils.cpp
@@ -1,21 +1,22 @@
 #include "stringutils.h"
 
+#include <string.h>
 #include <sstream>
 #include <algorithm>
 
 namespace stringutils
 {
-	std::vector<std::string> split(const std::string& s, char delim)
-	{
-			std::vector<std::string> elems;
-			std::stringstream ss(s);
-			std::string item;
-			while (std::getline(ss, item, delim)) 
-			{
-					elems.push_back(item);
-			}
-			return elems;
-	}
+  std::vector<std::string> split(const std::string& s, char delim)
+  {
+      std::vector<std::string> elems;
+      std::stringstream ss(s);
+      std::string item;
+      while (std::getline(ss, item, delim)) 
+      {
+          elems.push_back(item);
+      }
+      return elems;
+  }
 
   std::string trim(const std::string& s, char c)
   {
@@ -56,5 +57,10 @@ namespace stringutils
       dirname = "./";
       filename = path;
     }
+  }
+
+  bool caseInsensitiveCompare(const std::string& str1, const std::string& str2)
+  {
+    return strncasecmp(str1.c_str(), str2.c_str(), std::max(str1.size(), str2.size())) < 0;
   }
 }

--- a/src/stringutils.h
+++ b/src/stringutils.h
@@ -6,11 +6,12 @@
 
 namespace stringutils
 {
-	std::vector<std::string> split(const std::string& s, char delim);
+  std::vector<std::string> split(const std::string& s, char delim);
   std::string trim(const std::string& s, char c);
   std::string lower(const std::string& s);
   std::string upper(const std::string& s);
   void splitPath(const std::string& path, std::string& dirname, std::string& filename);
+  bool caseInsensitiveCompare(const std::string& str1, const std::string& str2);
 }
 
 #endif


### PR DESCRIPTION
Disc collections from multiple sources rarely follow the same naming
pattern. This change makes it easier to find a disc whose case is
unknown, without having to potentially search two different places in
the list.

Also a bunch of indentation fixes, as it happens.