### PR TITLE
Remember paths when loading/saving a disc, snapshot, tape or cartridge.

### DIFF
--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -1668,9 +1668,13 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    CPC.kbd_layout = conf.getStringValue("control", "kbd_layout", "keymap_us.map");
 
    CPC.max_tracksize = conf.getIntValue("file", "max_track_size", 6144-154);
+   CPC.current_snap_path =
    CPC.snap_path = conf.getStringValue("file", "snap_path", appPath + "/snap/");
+   CPC.current_cart_path =
    CPC.cart_path = conf.getStringValue("file", "cart_path", appPath + "/cart/");
+   CPC.current_dsk_path =
    CPC.dsk_path = conf.getStringValue("file", "dsk_path", appPath + "/disk/");
+   CPC.current_tape_path =
    CPC.tape_path = conf.getStringValue("file", "tape_path", appPath + "/tape/");
 
    int iFmt = FIRST_CUSTOM_DISK_FORMAT;

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -287,6 +287,11 @@ typedef struct {
    std::string rom_file[16];
    std::string rom_mf2;
 
+   std::string current_snap_path; // Last used snapshot path in the file dialog.
+   std::string current_cart_path; // Last used cartridge path in the file dialog.
+   std::string current_dsk_path;  // Last used disk path in the file dialog.
+   std::string current_tape_path; // Last used tape path in the file dialog.
+
    class InputMapper *InputMapper;
 } t_CPC;
 

--- a/src/gui/src/CapriceLoadSave.cpp
+++ b/src/gui/src/CapriceLoadSave.cpp
@@ -28,7 +28,7 @@ extern t_drive driveB;
 namespace wGui {
 
 CapriceLoadSave::CapriceLoadSave(const CRect& WindowRect, CWindow* pParent, CFontEngine* pFontEngine) :
-	CFrame(WindowRect, pParent, pFontEngine, "Load / Save", false)
+  CFrame(WindowRect, pParent, pFontEngine, "Load / Save", false)
 {
   SetModal(true);
   // Make this window listen to incoming CTRL_VALUECHANGE messages (used for updating drop down values)
@@ -38,7 +38,6 @@ CapriceLoadSave::CapriceLoadSave(const CRect& WindowRect, CWindow* pParent, CFon
   // File type (.SNA, .DSK, .TAP, .VOC)
   m_pTypeLabel = new CLabel(          CPoint(15, 25),             this, "File type: ");
   m_pTypeValue = new CDropDown( CRect(CPoint(80, 20), 150, 20),    this, false);
-  m_pTypeValue->AddItem(SListItem("Snapshot (.sna)"));
 #ifndef WITH_IPF
   m_pTypeValue->AddItem(SListItem("Drive A (.dsk)"));
   m_pTypeValue->AddItem(SListItem("Drive B (.dsk)"));
@@ -46,12 +45,13 @@ CapriceLoadSave::CapriceLoadSave(const CRect& WindowRect, CWindow* pParent, CFon
   m_pTypeValue->AddItem(SListItem("Drive A (.dsk/.ipf)"));
   m_pTypeValue->AddItem(SListItem("Drive B (.dsk/.ipf)"));
 #endif
+  m_pTypeValue->AddItem(SListItem("Snapshot (.sna)"));
   m_pTypeValue->AddItem(SListItem("Tape (.cdt/.voc)"));
   m_pTypeValue->AddItem(SListItem("Cartridge (.cpr)"));
   m_pTypeValue->SetListboxHeight(5);
   m_pTypeValue->SelectItem(0);
   m_pTypeValue->SetIsFocusable(true);
-  m_fileSpec = { ".sna", ".zip" };
+  m_fileSpec = { ".dsk", ".zip" };
 
   // Action: load / save
   m_pActionLabel = new CLabel(          CPoint(15, 55),             this, "Action: ");
@@ -65,7 +65,7 @@ CapriceLoadSave::CapriceLoadSave(const CRect& WindowRect, CWindow* pParent, CFon
   // Directory
   m_pDirectoryLabel = new CLabel(          CPoint(15, 85),             this, "Directory: ");
   m_pDirectoryValue = new CEditBox( CRect( CPoint(80, 80), 150, 20),    this);
-  m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.snap_path));
+  m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.current_dsk_path));
   m_pDirectoryValue->SetReadOnly(true);
 
   // File list
@@ -90,12 +90,12 @@ CapriceLoadSave::~CapriceLoadSave() = default;
 
 bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
 {
-	bool bHandled = false;
+  bool bHandled = false;
 
-	if (pMessage)
-	{
-		switch(pMessage->MessageType())
-		{
+  if (pMessage)
+  {
+    switch(pMessage->MessageType())
+    {
       case CMessage::CTRL_SINGLELCLICK:
         {
           if (pMessage->Destination() == this)
@@ -109,25 +109,37 @@ bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
               bool actionDone = false;
               std::string filename = m_pFileNameValue->GetWindowText();
               if(!filename.empty()) {
-                filename = m_pDirectoryValue->GetWindowText() + '/' + filename;
+                std::string directory = m_pDirectoryValue->GetWindowText();
+                filename = directory + '/' + filename;
                 switch (m_pActionValue->GetSelectedIndex()) {
                   case 0: // Load
                     {
                       DRIVE drive;
                       switch (m_pTypeValue->GetSelectedIndex()) {
-                        case 1: // Drive A
+                        case 0: // Drive A
                           drive = DSK_A;
                           actionDone = true;
+                          CPC.current_dsk_path = directory;
                           break;
-                        case 2: // Drive B
+                        case 1: // Drive B
                           drive = DSK_B;
                           actionDone = true;
+                          CPC.current_dsk_path = directory;
                           break;
-                        case 0: // Snapshot
+                        case 2: // Snapshot
+                          drive = OTHER;
+                          actionDone = true;
+                          CPC.current_snap_path = directory;
+                          break;
                         case 3: // Tape
+                          drive = OTHER;
+                          actionDone = true;
+                          CPC.current_tape_path = directory;
+                          break;
                         case 4: // Cartridge
                           drive = OTHER;
                           actionDone = true;
+                          CPC.current_cart_path = directory;
                           break;
                       }
                       if (actionDone) {
@@ -141,19 +153,19 @@ bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
                   case 1: // Save
                     // TODO(cpitrat): Ensure the proper extension is present in the filename, otherwise add it.
                     switch (m_pTypeValue->GetSelectedIndex()) {
-                      case 0: // Snapshot
-                        std::cout << "Save snapshot: " << filename << std::endl;
-                        snapshot_save(filename);
-                        actionDone = true;
-                        break;
-                      case 1: // Drive A
+                      case 0: // Drive A
                         std::cout << "Save dsk A: " << filename << std::endl;
                         dsk_save(filename, &driveA);
                         actionDone = true;
                         break;
-                      case 2: // Drive B
+                      case 1: // Drive B
                         std::cout << "Save dsk B: " << filename << std::endl;
                         dsk_save(filename, &driveB);
+                        actionDone = true;
+                        break;
+                      case 2: // Snapshot
+                        std::cout << "Save snapshot: " << filename << std::endl;
+                        snapshot_save(filename);
                         actionDone = true;
                         break;
                       case 3: // Tape
@@ -203,13 +215,8 @@ bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
         }
         if (pMessage->Destination() == m_pTypeValue) {
           switch (m_pTypeValue->GetSelectedIndex()) {
-            case 0: // Snapshot
-              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.snap_path));
-              m_fileSpec = { ".sna", ".zip" };
-              UpdateFilesList();
-              break;
-            case 1: // Drive A
-              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.dsk_path));
+            case 0: // Drive A
+              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.current_dsk_path));
 #ifndef WITH_IPF
               m_fileSpec = { ".dsk", ".zip" };
 #else
@@ -217,18 +224,23 @@ bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
 #endif
               UpdateFilesList();
               break;
-            case 2: // Drive B
-              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.dsk_path));
+            case 1: // Drive B
+              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.current_dsk_path));
               m_fileSpec = { ".dsk", ".zip" };
               UpdateFilesList();
               break;
+            case 2: // Snapshot
+              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.current_snap_path));
+              m_fileSpec = { ".sna", ".zip" };
+              UpdateFilesList();
+              break;
             case 3: // Tape
-              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.tape_path));
+              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.current_tape_path));
               m_fileSpec = { ".cdt", ".voc", ".zip" };
               UpdateFilesList();
               break;
             case 4: // Cartridge
-              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.cart_path));
+              m_pDirectoryValue->SetWindowText(simplifyDirPath(CPC.current_cart_path));
               m_fileSpec = { ".cpr", ".zip" };
               UpdateFilesList();
               break;
@@ -247,7 +259,7 @@ bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
           } else {
             m_pFileNameValue->SetWindowText(fn);
           }
-				}
+        }
         break;
 
       default :
@@ -257,7 +269,7 @@ bool CapriceLoadSave::HandleMessage(CMessage* pMessage)
   if (!bHandled) {
     bHandled = CFrame::HandleMessage(pMessage);
   }
-	return bHandled;
+  return bHandled;
 }
 
 std::string CapriceLoadSave::simplifyDirPath(std::string path)


### PR DESCRIPTION
Also made drive A disc the default when opening the dialog.

Plenty of games use several discs, and require flipping discs regularly
as the player moves around. Caprice32 remembering the last used path
means the player only has to open the dialog and select the new disc,
without having to navigate back to the game's directory each time.

Also sorry for the PR deluge. :) Just started using Caprice32, randomly fixing things as they come.