### PR TITLE
Fix autocmd high speed

### DIFF
--- a/cap32.cfg
+++ b/cap32.cfg
@@ -52,9 +52,9 @@ joystick_vkeyboard_button=10
 #   path to resources (menu images...)
 resources_path=/usr/local/share/caprice32/resources
 # boot_time
-#   Estimated time in seconds the CPC takes to boot.
-#   Caprice will wait this long before sending a provided autocmd.
-boot_time=2
+#   Estimated time in video frames the CPC takes to boot.
+#   Caprice will emulate this number of frames before starting to send a provided autocmd.
+boot_time=42
 
 [video]
 # src_width/height/bpp

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -105,7 +105,7 @@ byte *pbTapeImage = nullptr;
 byte keyboard_matrix[16];
 
 std::list<SDL_Event> virtualKeyboardEvents;
-dword lastVirtualEventFrameCount, dwFrameCountOverall = 0;
+dword nextVirtualEventFrameCount, dwFrameCountOverall = 0;
 
 byte *membank_config[8][4];
 
@@ -1975,7 +1975,7 @@ int cap32_main (int argc, char **argv)
    // Fill the buffer with autocmd if provided
    virtualKeyboardEvents = CPC.InputMapper->StringToEvents(args.autocmd);
    // Give some time to the CPC to start before sending any command
-   lastVirtualEventFrameCount = dwFrameCountOverall + CPC.boot_time;
+   nextVirtualEventFrameCount = dwFrameCountOverall + CPC.boot_time;
 
 // ----------------------------------------------------------------------------
 
@@ -1986,8 +1986,8 @@ int cap32_main (int argc, char **argv)
    bolDone = false;
 
    while (!bolDone) {
-      if(!virtualKeyboardEvents.empty() && lastVirtualEventFrameCount < dwFrameCountOverall) {
-        lastVirtualEventFrameCount = dwFrameCountOverall;
+      if(!virtualKeyboardEvents.empty() && nextVirtualEventFrameCount < dwFrameCountOverall) {
+        nextVirtualEventFrameCount = dwFrameCountOverall;
         SDL_PushEvent(&virtualKeyboardEvents.front());
         virtualKeyboardEvents.pop_front();
       }

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -1987,7 +1987,7 @@ int cap32_main (int argc, char **argv)
 
    while (!bolDone) {
       if(!virtualKeyboardEvents.empty() && nextVirtualEventFrameCount < dwFrameCountOverall) {
-        nextVirtualEventFrameCount = dwFrameCountOverall;
+        nextVirtualEventFrameCount = dwFrameCountOverall + 1; // Let CPC firmware debouncer time else it will eat repeated characters.
         SDL_PushEvent(&virtualKeyboardEvents.front());
         virtualKeyboardEvents.pop_front();
       }

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -105,7 +105,7 @@ byte *pbTapeImage = nullptr;
 byte keyboard_matrix[16];
 
 std::list<SDL_Event> virtualKeyboardEvents;
-dword lastVirtualEventTicks;
+dword lastVirtualEventFrameCount, dwFrameCountOverall = 0;
 
 byte *membank_config[8][4];
 
@@ -1975,7 +1975,7 @@ int cap32_main (int argc, char **argv)
    // Fill the buffer with autocmd if provided
    virtualKeyboardEvents = CPC.InputMapper->StringToEvents(args.autocmd);
    // Give some time to the CPC to start before sending any command
-   lastVirtualEventTicks = SDL_GetTicks() + CPC.boot_time * 1000;
+   lastVirtualEventFrameCount = dwFrameCountOverall + CPC.boot_time;
 
 // ----------------------------------------------------------------------------
 
@@ -1986,8 +1986,8 @@ int cap32_main (int argc, char **argv)
    bolDone = false;
 
    while (!bolDone) {
-      if(!virtualKeyboardEvents.empty() && lastVirtualEventTicks + 100 < SDL_GetTicks()) {
-        lastVirtualEventTicks = SDL_GetTicks();
+      if(!virtualKeyboardEvents.empty() && lastVirtualEventFrameCount < dwFrameCountOverall) {
+        lastVirtualEventFrameCount = dwFrameCountOverall;
         SDL_PushEvent(&virtualKeyboardEvents.front());
         virtualKeyboardEvents.pop_front();
       }
@@ -2240,6 +2240,7 @@ int cap32_main (int argc, char **argv)
          iExitCondition = z80_execute(); // run the emulation until an exit condition is met
 
          if (iExitCondition == EC_FRAME_COMPLETE) { // emulation finished rendering a complete frame?
+            dwFrameCountOverall++;
             dwFrameCount++;
             if (SDL_GetTicks() < osd_timing) {
                print(static_cast<dword *>(back_surface->pixels) + CPC.scr_line_offs, osd_message.c_str(), true);

--- a/test/integrated/dsk/test.sh
+++ b/test/integrated/dsk/test.sh
@@ -9,7 +9,7 @@ cd "$TSTDIR"
 touch "${LOGFILE}"
 
 # The CLS is here mostly to let time to the program to run
-$CAP32DIR/cap32 -c cap32.cfg -a CAP32_SCRNSHOT -a "run\"hello" -a "          " -a CAP32_EXIT hello.zip >> "${LOGFILE}" 2>&1
+$CAP32DIR/cap32 -c cap32.cfg -a CAP32_SCRNSHOT -a "         " -a "run\"hello" -a "                    " -a CAP32_EXIT hello.zip >> "${LOGFILE}" 2>&1
 
 if diff printer.dat expected.dat >> "${LOGFILE}"
 then


### PR DESCRIPTION
Fix #107 by counting emulated video frames instead of host (wall clock) time.
As an added bonus this allows to autocmd to work at high speed.

Added a one-frame delay between each key stroke else firmware debouncer eats duplicated letters. This could be optimized by adding a delay only on duplicated letters.

I've read that some user of other emulator use autotype on WinAPE for high volume entry like a complete BASIC program [(ref)](http://www.cpcwiki.eu/forum/applications/full-screen-basic-editor/msg153497/#msg153497). This direction make caprice32 a nice alternative to WinAPE (which is Windows-only).

If you accept this PR, please credit my real name (visible in git history).

Thank you for this nice emulator which code was clear enough to quickly offer this PR!
