### PR TITLE
Make "Limit emulation speed" persistent.

### DIFF
--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -1615,7 +1615,7 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    if ((CPC.speed < MIN_SPEED_SETTING) || (CPC.speed > MAX_SPEED_SETTING)) {
       CPC.speed = DEF_SPEED_SETTING;
    }
-   CPC.limit_speed = 1;
+   CPC.limit_speed = conf.getIntValue("system", "limit_speed", 1) & 1;
    CPC.auto_pause = conf.getIntValue("system", "auto_pause", 1) & 1;
    CPC.boot_time = conf.getIntValue("system", "boot_time", 5);
    CPC.printer = conf.getIntValue("system", "printer", 0) & 1;
@@ -1717,6 +1717,7 @@ void saveConfiguration (t_CPC &CPC, const std::string& configFilename)
    conf.setIntValue("system", "jumpers", CPC.jumpers);
 
    conf.setIntValue("system", "ram_size", CPC.ram_size); // 128KB RAM
+   conf.setIntValue("system", "limit_speed", CPC.limit_speed);
    conf.setIntValue("system", "speed", CPC.speed); // original CPC speed
    conf.setIntValue("system", "auto_pause", CPC.auto_pause);
    conf.setIntValue("system", "printer", CPC.printer);


### PR DESCRIPTION
# Context

* Wish to run unattended tests at maximum speed possible on host.
* UI menu includes a "Limit emulation speed" option that can be checked or not.

# Observed

* "Limit emulation speed" is not read nor written in config: always set to `speed_limit=1` on emulator start.

# Expected

* "Limit emulation speed" is read, obeyed and written in config.
* Alternative: command-line option, if config entry is not suitable.

# Result

Changing 3 lines is enough. Hence the PR.

# Benefit

Test case can do things like this:

    sed -e "s|limit_speed=.*|limit_speed=1|" -e "s|printer=.*|printer=1|" <$(CDTC_ROOT)/tool/caprice32/cap32_local.cfg >cap32_forunittest.cfg

# Regression potential

* Actual potential seem very low as default behavior is not changed.

Thank you for your attention.
