### PR TITLE
Fixed debian packaging process

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,16 +33,16 @@ Alternatively, the debug target also work:
 
 #### Debian/Ubuntu package:
 
-To build a debian package on Debian/Ubuntu distributions install the dependencies as mentioned above and the dpkg-dev package:
+To build a debian package on Debian/Ubuntu distributions, install the dependencies as mentioned above and the debian packaging helper packages:
 
 `sudo apt-get install dpkg-dev pbuilder`
 
 Then, to create a debian package:
 
  * fill in the required version in the debian/changelog file
- * compile with 'make VERSION=<my_version_string>
- * go to release/cap32_linux/caprice32-<version>/debian
- * execute 'debuild -us -uc --lintian-opts --profile debian' or 'pdebuild' if you want to run in a chrooted env. 
+ * compile with `make VERSION=<my_version_string>`
+ * go to `release/cap32_linux/caprice32-<version>/debian`
+ * execute `debuild -us -uc --lintian-opts --profile debian` or `pdebuild` if you want to run in a chrooted env.
 
 #### Windows target:
 

--- a/debian/patches/fix-install-path.patch
+++ b/debian/patches/fix-install-path.patch
@@ -2,16 +2,16 @@ Honor FHS to please debian
 
 --- a/cap32.cfg
 +++ b/cap32.cfg
-@@ -50,7 +50,7 @@
+@@ -50,7 +50,7 @@ joystick_menu_button=9
  joystick_vkeyboard_button=10
  # resources_path
  #   path to resources (menu images...)
 -resources_path=/usr/local/share/caprice32/resources
 +resources_path=/usr/share/caprice32/resources
  # boot_time
- #   Estimated time in seconds the CPC takes to boot.
- #   Caprice will wait this long before sending a provided autocmd.
-@@ -167,7 +167,7 @@
+ #   Estimated time in video frames the CPC takes to boot.
+ #   Caprice will emulate this number of frames before starting to send a provided autocmd.
+@@ -167,7 +167,7 @@ printer_file=./printer.dat
  sdump_dir=./screenshots
  
  [rom]


### PR DESCRIPTION
    Some commits modified the cap32.cfg file, preventing one
    debian specific patch to apply. Fixed this.
    Also, slightly improved INSTALL.md formatting w.r.t debian.