### PR TITLE
Dynamic ipf load

### DIFF
--- a/makefile
+++ b/makefile
@@ -45,10 +45,7 @@ IPATHS = -Isrc/ -Isrc/gui/includes -I$(MINGW_PATH)/include -I$(MINGW_PATH)/inclu
 LIBS = $(MINGW_PATH)/lib/libSDL.dll.a $(MINGW_PATH)/lib/libfreetype.dll.a $(MINGW_PATH)/lib/libz.dll.a $(MINGW_PATH)/lib/libpng16.dll.a $(MINGW_PATH)/lib/libpng.dll.a
 COMMON_CFLAGS = -DWINDOWS
 CXX = $(TRIPLE)-g++
-ifdef WITH_IPF
-COMMON_CFLAGS += -DWITH_IPF
-LIBS += $(MINGW_PATH)/bin/$(CAPSIPFDLL)
-endif
+
 else
 prefix = /usr/local
 TARGET = cap32
@@ -58,9 +55,12 @@ LIBS = `sdl-config --libs` -lz `pkg-config --libs freetype2` `pkg-config --libs 
 CXX ?= g++
 COMMON_CFLAGS = -fPIC
 ifdef WITH_IPF
-COMMON_CFLAGS += -DWITH_IPF
-LIBS += -lcapsimage
+LIBS += -ldl
 endif
+endif
+
+ifdef WITH_IPF
+COMMON_CFLAGS += -DWITH_IPF
 endif
 
 ifndef RELEASE

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -1797,7 +1797,11 @@ void doCleanUp ()
    SDL_Quit();
 }
 
-
+void cleanExit(int returnCode)
+{
+    doCleanUp();
+    exit(returnCode);
+}
 
 // TODO: Deduplicate showVKeyboard and showGui
 void showVKeyboard()
@@ -1914,11 +1918,10 @@ int cap32_main (int argc, char **argv)
       fprintf(stderr, "SDL_Init() failed: %s\n", SDL_GetError());
       exit(-1);
    }
-   atexit(doCleanUp); // install the clean up routine
 
    if(getcwd(chAppPath, sizeof(chAppPath)-1) == nullptr) { // get the location of the executable
       fprintf(stderr, "getcwd failed: %s\n", strerror(errno));
-      exit(-1);
+      cleanExit(-1);
    }
 
    loadConfiguration(CPC, getConfigurationFilename()); // retrieve the emulator configuration
@@ -1932,7 +1935,7 @@ int cap32_main (int argc, char **argv)
 
    if (video_init()) {
       fprintf(stderr, "video_init() failed. Aborting.\n");
-      exit(-1);
+      cleanExit(-1);
    }
 
    if (audio_init()) {
@@ -1962,7 +1965,7 @@ int cap32_main (int argc, char **argv)
    // pbGPBuffer to be initialized.
    if (emulator_init()) {
       fprintf(stderr, "emulator_init() failed. Aborting.\n");
-      exit(-1);
+      cleanExit(-1);
    }
 
    // Really load the various drives, if needed
@@ -2047,7 +2050,7 @@ int cap32_main (int argc, char **argv)
                            CPC.scr_window = CPC.scr_window ? 0 : 1;
                            if (video_init()) {
                               fprintf(stderr, "video_init() failed. Aborting.\n");
-                              exit(-1);
+                              cleanExit(-1);
                            }
                            audio_resume();
                            break;
@@ -2123,7 +2126,7 @@ int cap32_main (int argc, char **argv)
                            break;
 
                         case CAP32_EXIT:
-                           exit (0);
+                           cleanExit (0);
                            break;
 
                         case CAP32_FPS:
@@ -2226,7 +2229,7 @@ int cap32_main (int argc, char **argv)
                break;
 
             case SDL_QUIT:
-               exit(0);
+               cleanExit(0);
          }
       }
 

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -392,7 +392,7 @@ void audio_pause ();
 void audio_resume ();
 int video_init ();
 void video_shutdown ();
-void cleanExit(int);
+void cleanExit(int returnCode);
 
 // Return the path to the best (i.e: most specific) configuration file.
 // Priority order is:

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -392,6 +392,7 @@ void audio_pause ();
 void audio_resume ();
 int video_init ();
 void video_shutdown ();
+void cleanExit(int);
 
 // Return the path to the best (i.e: most specific) configuration file.
 // Priority order is:

--- a/src/errors.h
+++ b/src/errors.h
@@ -34,6 +34,7 @@
 #define ERR_BAD_MF2_ROM          31
 #define ERR_SDUMP                32
 #define ERR_CPR_INVALID          33
+#define ERR_IPF_DYNLIB_LOAD      34
 
 #define ERR_JOYSTICKS_INIT       45
 

--- a/src/ipf.cpp
+++ b/src/ipf.cpp
@@ -2,16 +2,20 @@
 // Contributed by softpres.org
 
 #ifdef WITH_IPF
-#include "ipf.h"
+
 #ifdef WINDOWS
 #include <windows.h>
+#else
+#include <dlfcn.h>
 #endif
+
 #include "cap32.h"
 #include "disk.h"
 #include "errors.h"
+#include "fileutils.h"
+#include "ipf.h"
 #include "log.h"
 #include "slotshandler.h"
-#include "fileutils.h"
 
 extern t_CPC CPC;
 
@@ -26,23 +30,117 @@ static word s_wCRC;
 static struct CapsTrackInfoT1 cti;
 static dword dwLockFlags = DI_LOCK_UPDATEFD|DI_LOCK_TYPE;
 
+// Declare here all the CAPS functions we will need to import.
+// This is not very elegant but we do not want to use a lib wrapper
+// to keep things simpler.
+static CapsLong (*_CAPSInit)(void);
+static CapsLong (*_CAPSExit)(void);
+static CapsLong (*_CAPSAddImage)(void);
+static CapsLong (*_CAPSRemImage)(CapsLong);
+static CapsLong (*_CAPSLockImage)(CapsLong, char *);
+static CapsLong (*_CAPSUnlockImage)(CapsLong);
+static CapsLong (*_CAPSGetImageInfo)(struct CapsImageInfo *, CapsLong id);
+static CapsLong (*_CAPSLockTrack)(void *, CapsLong, CapsULong, CapsULong, CapsULong);
+static CapsLong (*_CAPSUnlockTrack)(CapsLong, CapsULong, CapsULong);
+static CapsLong (*_CAPSGetVersionInfo)(void *, CapsULong);
+#ifdef WINDOWS
+static HMODULE handle;
+#else
+static void *handle;
+#endif
+
+static int unload_caps_library(void)
+{
+#ifdef WINDOWS
+	if (!FreeLibrary(handle)) return ERR_IPF_DYNLIB_LOAD;
+	return 0;
+#else
+	if (dlclose(handle)) return ERR_IPF_DYNLIB_LOAD;
+	return 0;
+#endif
+}
+
+static int load_caps_library(void)
+{
+#ifdef WINDOWS
+	handle = LoadLibrary("CAPSImg.dll");
+	if (!handle)
+	{
+		LOG_ERROR("CAPSImg.dll is required for IPF support");
+		return ERR_IPF_DYNLIB_LOAD;
+	}
+	else
+	{
+		_CAPSInit = reinterpret_cast<CapsLong (*)(void)>(GetProcAddress(handle, "CAPSInit"));
+		if (_CAPSInit == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		_CAPSExit = reinterpret_cast<CapsLong (*)(void)>(GetProcAddress(handle, "CAPSExit"));
+		if (_CAPSExit == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		_CAPSAddImage = reinterpret_cast<CapsLong (*)(void)>(GetProcAddress(handle, "CAPSAddImage"));
+		if (_CAPSAddImage == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		_CAPSRemImage = reinterpret_cast<CapsLong (*)(CapsLong)>(GetProcAddress(handle, "CAPSRemImage"));
+		if (_CAPSRemImage == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		_CAPSLockImage = reinterpret_cast<CapsLong (*)(CapsLong, char *)>(GetProcAddress(handle, "CAPSLockImage"));
+		if (_CAPSLockImage == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		_CAPSUnlockImage = reinterpret_cast<CapsLong (*)(CapsLong)>(GetProcAddress(handle, "CAPSUnlockImage"));
+		if (_CAPSUnlockImage == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		_CAPSGetImageInfo = reinterpret_cast<CapsLong (*)(struct CapsImageInfo *, CapsLong)>(GetProcAddress(handle, "CAPSGetImageInfo"));
+		if (_CAPSGetImageInfo == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		_CAPSLockTrack = reinterpret_cast<CapsLong (*)(void *, CapsLong, CapsULong, CapsULong, CapsULong)>(GetProcAddress(handle, "CAPSLockTrack"));
+		if (_CAPSLockTrack == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		_CAPSUnlockTrack = reinterpret_cast<CapsLong (*)(CapsLong, CapsULong, CapsULong)>(GetProcAddress(handle, "CAPSUnlockTrack"));
+		if (_CAPSUnlockTrack == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		_CAPSGetVersionInfo = reinterpret_cast<CapsLong (*)(void *, CapsULong)>(GetProcAddress(handle, "CAPSGetVersionInfo"));
+		if (_CAPSGetVersionInfo == NULL) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+		return 0;
+	}
+#else
+	handle = dlopen("libcapsimage.so.4", RTLD_LAZY);
+	if (!handle)
+	{
+		LOG_ERROR("Cannot open libcapsimage.so.4 needed for IPF support");
+		return ERR_IPF_DYNLIB_LOAD;
+	}
+	dlerror();
+	_CAPSInit = reinterpret_cast<CapsLong (*)(void)>(dlsym(handle, "CAPSInit"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	_CAPSExit = reinterpret_cast<CapsLong (*)(void)>(dlsym(handle, "CAPSExit"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	_CAPSAddImage = reinterpret_cast<CapsLong (*)(void)>(dlsym(handle, "CAPSAddImage"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	_CAPSRemImage = reinterpret_cast<CapsLong (*)(CapsLong)>(dlsym(handle, "CAPSRemImage"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	_CAPSLockImage = reinterpret_cast<CapsLong (*)(CapsLong, char *)>(dlsym(handle, "CAPSLockImage"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	_CAPSUnlockImage = reinterpret_cast<CapsLong (*)(CapsLong)>(dlsym(handle, "CAPSUnlockImage"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	_CAPSGetImageInfo = reinterpret_cast<CapsLong (*)(struct CapsImageInfo *, CapsLong)>(dlsym(handle, "CAPSGetImageInfo"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	_CAPSLockTrack = reinterpret_cast<CapsLong (*)(void *, CapsLong, CapsULong, CapsULong, CapsULong)>(dlsym(handle, "CAPSLockTrack"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	_CAPSUnlockTrack = reinterpret_cast<CapsLong (*)(CapsLong, CapsULong, CapsULong)>(dlsym(handle, "CAPSUnlockTrack"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	_CAPSGetVersionInfo = reinterpret_cast<CapsLong (*)(void *, CapsULong)>(dlsym(handle, "CAPSGetVersionInfo"));
+	if (dlerror()) { unload_caps_library(); return ERR_IPF_DYNLIB_LOAD; }
+	return 0;
+#endif
+}
 // CRC-16 CCITT, for track level header and data checksums
 static void Crc (byte b_)
 {
    static word awCRC[256];
 
-    if (!awCRC[1])
-    {
-        for (int i = 0 ; i < 256 ; i++)
-        {
-            word w = i << 8;
-            for (int j = 0 ; j < 8 ; j++)
-                w = (w << 1) ^ ((w & 0x8000) ? 0x1021 : 0);
-            awCRC[i] = w;
-        }
-    }
+   if (!awCRC[1])
+   {
+      for (int i = 0 ; i < 256 ; i++)
+      {
+         word w = i << 8;
+         for (int j = 0 ; j < 8 ; j++)
+             w = (w << 1) ^ ((w & 0x8000) ? 0x1021 : 0);
+         awCRC[i] = w;
+      }
+   }
 
-	s_wCRC = (s_wCRC << 8) ^ awCRC[((s_wCRC >> 8) ^ b_) & 0xff];
+   s_wCRC = (s_wCRC << 8) ^ awCRC[((s_wCRC >> 8) ^ b_) & 0xff];
 }
 
 // Read an MFM byte from the track
@@ -269,7 +367,7 @@ void ipf_track_hook (t_drive *drive)
 
 	// Re-lock and update the track (note: don't use CAPSUnlockTrack() first as it resets the flakey data RNG!)
 	cti.type = 1;
-	if (CAPSLockTrack(reinterpret_cast<CapsTrackInfo*>(&cti), id, cyl, head, dwLockFlags) == imgeOk)
+	if (_CAPSLockTrack(reinterpret_cast<CapsTrackInfo*>(&cti), id, cyl, head, dwLockFlags) == imgeOk)
 	{
 		t_track *pt = &drive->track[cyl][head];
 
@@ -290,10 +388,10 @@ void ipf_eject_hook (t_drive *drive)
 {
 	long id = drive->ipf_id;
 
-	CAPSUnlockImage(id);
-	CAPSRemImage(id);
-	CAPSExit();
-
+	_CAPSUnlockImage(id);
+	_CAPSRemImage(id);
+	_CAPSExit();
+	unload_caps_library();
 	drive->altered = 0; // discard modifications
 	drive->eject_hook = nullptr;
 }
@@ -343,10 +441,10 @@ int ipf_load (const std::string &filename, t_drive *drive)
 
 	FILE *f = fopen(filename.c_str(), "rb");
 	if (!f)
-  {
+    {
 		LOG_ERROR("Couldn't open file: " << filename);
 		return ERR_DSK_INVALID;
-  }
+    }
 
 	// Check for IPF file signature
 	if (!fread(sz, 4, 1, f) || fclose(f) || memcmp(sz, "CAPS", sizeof(sz)))
@@ -357,18 +455,13 @@ int ipf_load (const std::string &filename, t_drive *drive)
 	}
 
 	// Ensure the SPS library is present before we try to use the delay-load calls
-#ifdef WINDOWS
-	if (!LoadLibrary("CAPSImg.dll"))
-	{
-		LOG_ERROR("CAPSImg.dll is required for IPF support");
-		return ERR_DSK_INVALID;
-	}
-#endif
+	int sts = load_caps_library();
+	if (sts) return sts;
 
 	// Check that the DLL supports the CapsTrackInfoT1 structure we need
-	if (CAPSGetVersionInfo(&vi, 0) != imgeOk || vi.release < 4) // compatible DLL?
+	if (_CAPSGetVersionInfo(&vi, 0) != imgeOk || vi.release < 4) // compatible DLL?
 	{
-		LOG_ERROR("CAPSImg.dll is too old, please upgrade it");
+		LOG_ERROR("IPF shared library is too old. Requiring version >=4. Please upgrade it");
 		return ERR_DSK_INVALID;
 	}
 
@@ -376,29 +469,31 @@ int ipf_load (const std::string &filename, t_drive *drive)
 	dwLockFlags |= vi.flag & (DI_LOCK_OVLBIT|DI_LOCK_TRKBIT);
 
 	// Initialise the library
-	if (CAPSInit() != imgeOk)
+	if (_CAPSInit() != imgeOk)
 	{
-		LOG_ERROR("CAPSImg.dll initialisation failed!");
+		LOG_ERROR("IPF shared library initialisation failed!");
 		return ERR_DSK_INVALID;
 	}
 
 	// Create a new image container
-	id = CAPSAddImage();
+	id = _CAPSAddImage();
 
 	// Attach the IPF file to the container
-	if (CAPSLockImage(id, const_cast<char*>(filename.c_str())) != imgeOk)
+	if (_CAPSLockImage(id, const_cast<char*>(filename.c_str())) != imgeOk)
 	{
-		CAPSRemImage(id);
-		CAPSExit();
+		_CAPSRemImage(id);
+		_CAPSExit();
+		unload_caps_library();
 		LOG_ERROR("Couldn't lock image: " << filename);
 		return ERR_DSK_INVALID;
 	}
 
 	// Get details about the contents of the image
-	if (CAPSGetImageInfo(&cii, id) != imgeOk)
+	if (_CAPSGetImageInfo(&cii, id) != imgeOk)
 	{
-		CAPSRemImage(id);
-		CAPSExit();
+		_CAPSRemImage(id);
+		_CAPSExit();
+		unload_caps_library();
 		LOG_ERROR("Couldn't get image info: " << filename);
 		return ERR_DSK_INVALID;
 	}
@@ -416,12 +511,13 @@ int ipf_load (const std::string &filename, t_drive *drive)
 		for (byte head = static_cast<byte>(cii.minhead); head <= cii.maxhead ; head++)
 		{
 			cti.type = 1;
-			if (CAPSLockTrack(reinterpret_cast<CapsTrackInfo*>(&cti), id, cyl, head, dwLockFlags) != imgeOk)
+			if (_CAPSLockTrack(reinterpret_cast<CapsTrackInfo*>(&cti), id, cyl, head, dwLockFlags) != imgeOk)
 			{
-				LOG_ERROR("Failed to lock IPF track, please upgrade CAPSImg.dll");
-				CAPSUnlockImage(id);
-				CAPSRemImage(id);
-				CAPSExit();
+				LOG_ERROR("Failed to lock IPF track, please upgrade IPF shared library.");
+				_CAPSUnlockImage(id);
+				_CAPSRemImage(id);
+				_CAPSExit();
+				unload_caps_library();
 				return ERR_DSK_INVALID;
 			}
 
@@ -432,7 +528,7 @@ int ipf_load (const std::string &filename, t_drive *drive)
 			else
 				ReadTrack(pt);
 
-			CAPSUnlockTrack(id, cyl, head);
+			_CAPSUnlockTrack(id, cyl, head);
 		}
 	}
 

--- a/src/ipf.cpp
+++ b/src/ipf.cpp
@@ -55,7 +55,7 @@ static int unload_caps_library(void)
 	if (!FreeLibrary(handle)) return ERR_IPF_DYNLIB_LOAD;
 	return 0;
 #else
-	if (dlclose(handle)) return ERR_IPF_DYNLIB_LOAD;
+	if (dlclose(handle) != 0) return ERR_IPF_DYNLIB_LOAD;
 	return 0;
 #endif
 }

--- a/src/slotshandler.cpp
+++ b/src/slotshandler.cpp
@@ -1356,7 +1356,7 @@ void cartridge_load ()
   if (CPC.model >= 3) {
      if (file_load(CPC.cart_file, OTHER)) {
         fprintf(stderr, "Load of cartridge failed. Aborting.\n");
-        exit(-1);
+        cleanExit(-1);
      }
   }
 }


### PR DESCRIPTION
Use dynamic loading for libcaps (both on windows and linux). Will allow caprice32 to launch even if libcaps shared lib is not installed on the system.
Will also ease packaging (no need to distribute libcaps along the binary package if we do not want to).