### PR TITLE
Added IPF support to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,17 @@ addons:
 #    - gdb
 before_script:
     - export CXX=g++-4.8
+    - wget http://softpres.org/_media/files:ipflib42_linux-x86_64.tar.gz -O /tmp/ipflib42_linux-x86_64.tar.gz
+    - tar -xf /tmp/ipflib42_linux-x86_64.tar.gz 2>&1 >/dev/null
+    - sudo cp -r x86_64-linux-gnu-capsimage/include/caps /usr/include
+
 # Build and test both in release and debug to ensure both works fine
 script: 
 #To uncomment in case a core occurs:
 # - ulimit -c unlimited
 # - sudo sysctl kernel.core_pattern=core
- - make
- - make unit_test
+ - make WITH_IPF=true
+ - make WITH_IPF=true unit_test
  - make e2e_test
  - make clean
  - make debug CFLAGS=-Wno-literal-suffix


### PR DESCRIPTION
Let's pull in the IPF library into Travis CI.
We download the x86_64 package, but since we only use the includes, we should be OK whatever the actul Travis build arch (which will very likely be x86_64 anyway).
Tested on Travis - seems to work just fine.