### PR TITLE
implemented 4 different green color modes, see help and manual.

### DIFF
--- a/doc/man.html
+++ b/doc/man.html
@@ -1,5 +1,5 @@
-<!-- Creator     : groff version 1.22.3 -->
-<!-- CreationDate: Fri Jun  9 09:16:47 2017 -->
+<!-- Creator     : groff version 1.22.4 -->
+<!-- CreationDate: Wed Mar 25 00:31:08 2020 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -100,20 +100,26 @@ configuration file was specified using the <b>--cfg_file</b>
 command line switch, Caprice32 will try and use it. If no
 configuration file was specified, or the configuration file
 specified does not exist, Caprice32 will try and open, in
-this order: <b>$CWD/cap32.cfg</b> ($CWD being the directory
-where the cap32 executable resides), then a
-<b>.cap32.cfg</b> file in the user home directory, then
-<b>/etc/cap32.cfg</b>. Caprice32 will use the first valid
-file it finds. If no configuration file is found, a default
-configuration will be used.</p>
+this order: <br>
+- <b>$CWD/cap32.cfg</b> ($CWD being the directory where the
+cap32 executable resides) <br>
+- <b>cap32.cfg</b> file in the location pointed to by the
+XDG_CONFIG_HOME environment variable. If XDG_CONFIG_HOME is
+undefined, it will look at $HOME/.config/ as default
+XDG_CONFIG_HOME directory. <br>
+- <b>$HOME/.cap32.cfg</b> for compatibility. <br>
+- <b>/etc/cap32.cfg</b>. <br>
+Caprice32 will use the first valid file it finds. If no
+configuration file is found, a default configuration will be
+used.</p>
 
 <p style="margin-left:22%; margin-top: 1em">The
 configuration file contains various configuration
 parameters, some of which can be modified from the GUI. When
 saving the configuration from the GUI, it will be written in
-the configuration file specified by the <b>--cfg_file</b>
-switch, if it exists, else in $CWD/cap32.cfg if it exists,
-otherwise in $HOME/.cap32.cfg.</p>
+the configuration file following the same order than
+previously described, except for the addition of the write
+permission condition.</p>
 
 <p style="margin-left:22%; margin-top: 1em">Most of the
 configuration file entries are commented in the
@@ -203,6 +209,16 @@ commands. For example: cap32 -a &rsquo;print
 
 <p style="margin-left:22%;">use FILE as the emulator
 configuration file.</p>
+
+<p style="margin-left:11%;"><b>-g</b>,
+<b>--greenmode</b>=<i>MODE</i></p>
+
+<p style="margin-left:22%;">adjust the color palette for
+the green screen mode. Possible values for MODE are 0 to 3,
+where 0=classic caprice green colors, 1=as mode 0, but with
+blue value adjustment, 2=lebretro proposal implementation
+(see https://github.com/ColinPitrat/caprice32/issues/135)
+and 3=libretro proposal with blue adjustment.</p>
 
 <p style="margin-left:11%;"><b>-h</b>, <b>--help</b></p>
 

--- a/doc/man6/cap32.6
+++ b/doc/man6/cap32.6
@@ -118,6 +118,9 @@ pass command to execute to the emulator. The option can be repeated to pass mult
 \fB\-c\fR, \fB\-\-cfg_file\fR=\fIFILE\fR
 use FILE as the emulator configuration file.
 .TP
+\fB\-g\fR, \fB\-\-greenmode\fR=\fIMODE\fR
+adjust the color palette for the green screen mode. Possible values for MODE are 0 to 3, where 0=classic caprice green colors, 1=as mode 0, but with blue value adjustment, 2=lebretro proposal implementation (see https://github.com/ColinPitrat/caprice32/issues/135) and 3=libretro proposal with blue adjustment.
+.TP
 \fB\-h\fR, \fB\-\-help\fR
 display short help and exits
 .TP

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -15,6 +15,7 @@ const struct option long_options[] =
 {
    {"autocmd",  required_argument, nullptr, 'a'},
    {"cfg_file", required_argument, nullptr, 'c'},
+   {"greenmode",required_argument, nullptr, 'g'}, 
    {"version",  no_argument, nullptr, 'V'},
    {"help",     no_argument, nullptr, 'h'},
    {"verbose",  no_argument, nullptr, 'v'},
@@ -33,11 +34,16 @@ void usage(std::ostream &os, char *progPath, int errcode)
 
    os << "Usage: " << progname << " [options] <slotfile(s)>\n";
    os << "\nSupported options are:\n";
-   os << "   -a/--autocmd=<command>: execute command as soon as the emulator starts.\n";
-   os << "   -c/--cfg_file=<file>:   use <file> as the emulator configuration file instead of the default.\n";
-   os << "   -h/--help:              shows this help\n";
-   os << "   -V/--version:           outputs version and exit\n";
-   os << "   -v/--verbose:           be talkative\n";
+   os << "   -a/--autocmd=<command>:  execute command as soon as the emulator starts.\n";
+   os << "   -c/--cfg_file=<file>:    use <file> as the emulator configuration file instead of the default.\n";
+   os << "   -g/--greenmode=<0|1|2|3>:adjust the color profile for green screen simulation.\n";
+   os << "                            0=classic caprice green color scheme\n";
+   os << "                            1=as mode 0, but added some blue to increase realism\n";
+   os << "                            2=improved palette proposed by libretro project\n";
+   os << "                            3=as mode 2, but added some blue to increase realism\n";
+   os << "   -h/--help:               shows this help\n";
+   os << "   -V/--version:            outputs version and exit\n";
+   os << "   -v/--verbose:            be talkative\n";
    os << "\nslotfiles is an optional list of files giving the content of the various CPC ports.\n";
    os << "Ports files are identified by their extension. Supported formats are .dsk (disk), .cdt or .voc (tape), .cpr (cartridge), .sna (snapshot), or .zip (archive containing one or more of the supported ports files).\n";
    os << "\nExample: " << progname << " sorcery.dsk\n";
@@ -93,7 +99,7 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
 
    optind = 0; // To please test framework, when this function is called multiple times !
    while(true) {
-      c = getopt_long (argc, argv, "a:c:hvV",
+      c = getopt_long (argc, argv, "a:c:g:hvV",
                        long_options, &option_index);
 
       /* Detect the end of the options. */
@@ -110,6 +116,14 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
 
          case 'c':
             args.cfgFilePath = optarg;
+            break;
+
+         case 'g':
+            args.greenMode = atoi(optarg);
+            if (args.greenMode < 0 || args.greenMode > 3) {
+               printf("illegal greenmode value:%s\n", optarg);
+               usage(std::cout, argv[0], 0);
+            }
             break;
 
          case 'h':

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -10,6 +10,7 @@ class CapriceArgs
       CapriceArgs();
       std::string autocmd;
       std::string cfgFilePath;
+      int greenMode;
 };
 
 std::string replaceCap32Keys(std::string command);


### PR DESCRIPTION
this PR of caprice now supports --greenmode=<0|1|2|3>
I added quite a lot blue to the greenmode 1 and 3 to match my cpc green screen. It is close now concerning RGB, although the maqic glow of the phosphore seems not to be that simple to reproduce on an LCD. On the other side, the CRT simulation https://github.com/Swordfish90/cool-retro-term shows what can be achieved. That looks absolutely impressive and I really love to use that thing as well. Maybe in the far future caprice32 could benefit from this? At the moment I have not yet any clue how that is done.