### PR TITLE
Feature/green monitor palette2

### DIFF
--- a/cap32.cfg
+++ b/cap32.cfg
@@ -96,6 +96,17 @@ scr_fps=1
 #   0: Color display
 #   1: Monochrome display
 scr_tube=0
+#scr_green_mode
+#   Useful when scr_tube=1
+#   0: green luminance conversion by original author (classic)
+#   1: green luminance conversion proposed by the libretro prject
+scr_green_mode=0
+#scr_green_blue_percent
+#   Adjustment of the blue color part in the monochrome (green) display
+#   Integer number ranging from 0 (pure green) to 100 (turqoise)
+#   A value of around 30 is considered most realistic compared to real
+#   hardware.
+scr_green_blue_percent=30
 # scr_intensity
 #   Screen cathodic tube intensity
 #   Integer number ranging from 5 (dark) to 10 (light)

--- a/cap32.cfg
+++ b/cap32.cfg
@@ -100,7 +100,7 @@ scr_tube=0
 #   Useful when scr_tube=1
 #   0: green luminance conversion by original author (classic)
 #   1: green luminance conversion proposed by the libretro prject
-scr_green_mode=0
+scr_green_mode=1
 #scr_green_blue_percent
 #   Adjustment of the blue color part in the monochrome (green) display
 #   Integer number ranging from 0 (pure green) to 100 (turqoise)

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -141,7 +141,9 @@ double colours_rgb[32][3] = {
    { 0.5, 0.0, 0.0 }, { 0.5, 0.0, 1.0 },{ 0.5, 0.5, 0.0 }, { 0.5, 0.5, 1.0 }
 };
 
-double colours_green[32] = {
+// original RGB color to GREEN LUMA converted by Ulrich Doewich
+// unknown formula.
+double colours_green_classic[32] = {
    0.5647, 0.5647, 0.7529, 0.9412,
    0.1882, 0.3765, 0.4706, 0.6588,
    0.3765, 0.9412, 0.9098, 0.9725,
@@ -151,6 +153,62 @@ double colours_green[32] = {
    0.2824, 0.8471, 0.8157, 0.8784,
    0.2510, 0.3137, 0.5333, 0.5961
 };
+
+// added by a proposal from libretro project,
+// see https://github.com/ColinPitrat/caprice32/issues/135
+
+double colours_green_libretro[32] = {
+   0.5755,  0.5755,  0.7534,  0.9718,
+   0.1792,  0.3976,  0.4663,  0.6847,
+   0.3976,  0.9718,  0.9136,  1.0300,
+   0.3394,  0.4558,  0.6265,  0.7429,
+   0.1792,  0.7534,  0.6952,  0.8116,
+   0.1210,  0.2374,  0.4081,  0.5245,
+   0.2884,  0.8626,  0.8044,  0.9208,
+   0.2302,  0.3466,  0.5173,  0.6337
+};
+
+// interface to use the palette also from tests
+double *video_get_green_palette(int mode) {
+   if (!mode)
+      return colours_green_classic;
+   else
+      return colours_green_libretro;
+}
+
+double *video_get_rgb_color(int color) {
+   return colours_rgb[color];
+}
+
+void testGreenPalette() {
+
+   double precision = 0.0001;
+
+   double G_LUMA_R =    0.2427;
+   double G_LUMA_G =    0.6380;
+   double G_LUMA_B =    0.1293;
+   double G_LUMA_BASE = 0.071;
+   double G_LUMA_COEF = 0.100;
+   double G_LUMA_PRIM = 0.050;
+
+   //test the new libretro palette (mode 1)
+   double *green_palette = video_get_green_palette(1);
+
+   for (int color = 0; color < 32; color++) {
+      double r = colours_rgb[color][0];
+      double g = colours_rgb[color][1];
+      double b = colours_rgb[color][2];
+
+      double green_luma = ((G_LUMA_R * r) + (G_LUMA_G * g) + (G_LUMA_B * b));
+         green_luma += (G_LUMA_BASE + G_LUMA_PRIM - (G_LUMA_COEF * green_luma));
+
+      double delta = abs(green_luma - green_palette[color]);
+
+      if (delta > precision) {
+    	  printf("warning green_luma value differs from calculated value:%f %f\n", green_luma, green_palette[color]);
+      }
+   }
+}
 
 SDL_Color colours[32];
 
@@ -1316,13 +1374,23 @@ int video_set_palette ()
       }
    } else {
       for (int n = 0; n < 32; n++) {
+         double *colours_green = video_get_green_palette(CPC.scr_green_mode);
+
          dword green = static_cast<dword>(colours_green[n] * (CPC.scr_intensity / 10.0) * 255);
          if (green > 255) {
-            green = 255;
+             green = 255;
          }
+
+         dword blue = static_cast<dword>(0.01 * CPC.scr_green_blue_percent * colours_green[n] * (CPC.scr_intensity / 10.0) * 255);
+
+         // unlikely, but we care though
+         if (blue > 255) {
+             blue = 255;
+         }
+
          colours[n].r = 0;
          colours[n].g = green;
-         colours[n].b = 0;
+         colours[n].b = blue;
       }
    }
 
@@ -1651,6 +1719,9 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    }
    CPC.scr_window = conf.getIntValue("video", "scr_window", 1) & 1;
 
+   CPC.scr_green_mode = conf.getIntValue("video", "scr_green_mode", 0) & 1;
+   CPC.scr_green_blue_percent = conf.getIntValue("video", "scr_green_blue_percent", 0);
+
    CPC.snd_enabled = conf.getIntValue("sound", "enabled", 1) & 1;
    CPC.snd_playback_rate = conf.getIntValue("sound", "playback_rate", 2);
    if (CPC.snd_playback_rate > (MAX_FREQ_ENTRIES-1)) {
@@ -1740,6 +1811,9 @@ void saveConfiguration (t_CPC &CPC, const std::string& configFilename)
    conf.setIntValue("video", "scr_intensity", CPC.scr_intensity);
    conf.setIntValue("video", "scr_remanency", CPC.scr_remanency);
    conf.setIntValue("video", "scr_window", CPC.scr_window);
+
+   conf.setIntValue("video", "scr_green_mode", CPC.scr_green_mode);
+   conf.setIntValue("video", "scr_green_blue_percent", CPC.scr_green_blue_percent);
 
    conf.setIntValue("sound", "enabled", CPC.snd_enabled);
    conf.setIntValue("sound", "playback_rate", CPC.snd_playback_rate);
@@ -1913,6 +1987,8 @@ int cap32_main (int argc, char **argv)
    bool take_screenshot = false;
    SDL_Event event;
    std::vector<std::string> slot_list;
+
+   testGreenPalette();
 
    parseArguments(argc, argv, slot_list, args);
 

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -180,36 +180,6 @@ double *video_get_rgb_color(int color) {
    return colours_rgb[color];
 }
 
-void testGreenPalette() {
-
-   double precision = 0.0001;
-
-   double G_LUMA_R =    0.2427;
-   double G_LUMA_G =    0.6380;
-   double G_LUMA_B =    0.1293;
-   double G_LUMA_BASE = 0.071;
-   double G_LUMA_COEF = 0.100;
-   double G_LUMA_PRIM = 0.050;
-
-   //test the new libretro palette (mode 1)
-   double *green_palette = video_get_green_palette(1);
-
-   for (int color = 0; color < 32; color++) {
-      double r = colours_rgb[color][0];
-      double g = colours_rgb[color][1];
-      double b = colours_rgb[color][2];
-
-      double green_luma = ((G_LUMA_R * r) + (G_LUMA_G * g) + (G_LUMA_B * b));
-         green_luma += (G_LUMA_BASE + G_LUMA_PRIM - (G_LUMA_COEF * green_luma));
-
-      double delta = abs(green_luma - green_palette[color]);
-
-      if (delta > precision) {
-    	  printf("warning green_luma value differs from calculated value:%f %f\n", green_luma, green_palette[color]);
-      }
-   }
-}
-
 SDL_Color colours[32];
 
 byte bit_values[8] = {
@@ -1987,8 +1957,6 @@ int cap32_main (int argc, char **argv)
    bool take_screenshot = false;
    SDL_Event event;
    std::vector<std::string> slot_list;
-
-   testGreenPalette();
 
    parseArguments(argc, argv, slot_list, args);
 

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -190,6 +190,8 @@ typedef struct {
    unsigned int scr_bpp;
    unsigned int scr_bps;
    unsigned int scr_line_offs;
+   unsigned int scr_green_mode;
+   unsigned int scr_green_blue_percent;
    unsigned char *scr_base;
    unsigned char *scr_pos;
    void (*scr_render)();
@@ -419,4 +421,6 @@ void ResetAYChipEmulation();
 void InitAYCounterVars();
 void InitAY();
 
+double *video_get_green_palette(int mode);
+double *video_get_rgb_color(int color);
 #endif

--- a/test/green_palette.cpp
+++ b/test/green_palette.cpp
@@ -24,13 +24,8 @@ TEST(GreenPalette, ValuesMatchFormula)
 	  double green_luma = ((G_LUMA_R * r) + (G_LUMA_G * g) + (G_LUMA_B * b));
 		 green_luma += (G_LUMA_BASE + G_LUMA_PRIM - (G_LUMA_COEF * green_luma));
 
-	  double delta = abs(green_luma - green_palette[color]);
-
-	  if (delta > precision) {
-		  printf("warning green_luma value differs from calculated value:%f %f\n", green_luma, green_palette[color]);
-	  }
-
-	  ASSERT_TRUE(delta <= precision);
+      EXPECT_NEAR(green_luma, green_palette[color], precision) <<
+    		  "green_luma value differs for " << color << ".";
    }
 }
 

--- a/test/green_palette.cpp
+++ b/test/green_palette.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include "cap32.h"
+
+TEST(GreenPalette, ValuesMatchFormula)
+{
+   double precision = 0.0001;
+
+   double G_LUMA_R =    0.2427;
+   double G_LUMA_G =    0.6380;
+   double G_LUMA_B =    0.1293;
+   double G_LUMA_BASE = 0.071;
+   double G_LUMA_COEF = 0.100;
+   double G_LUMA_PRIM = 0.050;
+
+   //test the new libretro palette (mode 1)
+   double *green_palette = video_get_green_palette(1);
+
+   for (int color = 0; color < 32; color++) {
+	  double *colours_rgb = video_get_rgb_color(color);
+	  double r = colours_rgb[0];
+	  double g = colours_rgb[1];
+	  double b = colours_rgb[2];
+
+	  double green_luma = ((G_LUMA_R * r) + (G_LUMA_G * g) + (G_LUMA_B * b));
+		 green_luma += (G_LUMA_BASE + G_LUMA_PRIM - (G_LUMA_COEF * green_luma));
+
+	  double delta = abs(green_luma - green_palette[color]);
+
+	  if (delta > precision) {
+		  printf("warning green_luma value differs from calculated value:%f %f\n", green_luma, green_palette[color]);
+	  }
+
+	  ASSERT_TRUE(delta <= precision);
+   }
+}
+


### PR DESCRIPTION
alternative rgb to green palette conversion.
two more variables are introduced in the configuration file
1. scr_green_mode (0=classic/1=libretro)
2. scr_green_blue_percent (0-100) percentage of blue in green screen mode

now there is also a unit test to check if the used values from the table match the
formula given.