### PR TITLE
Implement a warning dialog when leaving without having saved changes

### DIFF
--- a/src/asic.cpp
+++ b/src/asic.cpp
@@ -210,7 +210,7 @@ bool asic_register_page_write(word addr, byte val) {
          color += 16;
       }
       asic.sprites[id][x][y] = color;
-      //LOG_DEBUG("Received sprite data for sprite " << id << ": x=" << x << ", y=" << y << ", color=" << static_cast<int>(val));
+      LOG_DEBUG("Received sprite data for sprite " << id << ": x=" << x << ", y=" << y << ", color=" << static_cast<int>(val));
    } else if (addr >= 0x6000 && addr < 0x607D) {
       int id = ((addr - 0x6000) >> 3);
       int type = (addr & 0x7);
@@ -218,28 +218,28 @@ bool asic_register_page_write(word addr, byte val) {
          case 0:
             // X position
             asic.sprites_x[id] = (asic.sprites_x[id] & 0xFF00) | val;
-            //LOG_DEBUG("Received sprite X for sprite " << id << " x=" << asic.sprites_x[id]);
+            LOG_DEBUG("Received sprite X for sprite " << id << " x=" << asic.sprites_x[id]);
             // Mirrored in RAM image 4 bytes after
             pbRegisterPage[(addr & 0x3FFF) + 4] = val;
             break;
          case 1:
             // X position
             asic.sprites_x[id] = (asic.sprites_x[id] & 0x00FF) | (val << 8);
-            //LOG_DEBUG("Received sprite X for sprite " << id << " x=" << asic.sprites_x[id]);
+            LOG_DEBUG("Received sprite X for sprite " << id << " x=" << asic.sprites_x[id]);
             // Mirrored in RAM image 4 bytes after
             pbRegisterPage[(addr & 0x3FFF) + 4] = val;
             break;
          case 2:
             // Y position
             asic.sprites_y[id] = ((asic.sprites_y[id] & 0xFF00) | val);
-            //LOG_DEBUG("Received sprite Y for sprite " << id << " y=" << asic.sprites_y[id]);
+            LOG_DEBUG("Received sprite Y for sprite " << id << " y=" << asic.sprites_y[id]);
             // Mirrored in RAM image 4 bytes after
             pbRegisterPage[(addr & 0x3FFF) + 4] = val;
             break;
          case 3:
             // Y position
             asic.sprites_y[id] = ((asic.sprites_y[id] & 0x00FF) | (val << 8));
-            //LOG_DEBUG("Received sprite Y for sprite " << id << " y=" << asic.sprites_y[id]);
+            LOG_DEBUG("Received sprite Y for sprite " << id << " y=" << asic.sprites_y[id]);
             // Affect RAM image
             // Mirrored in RAM image 4 bytes after
             pbRegisterPage[(addr & 0x3FFF) + 4] = val;
@@ -248,6 +248,7 @@ bool asic_register_page_write(word addr, byte val) {
             // Magnification
             asic.sprites_mag_x[id] = decode_magnification(val >> 2);
             asic.sprites_mag_y[id] = decode_magnification(val);
+            LOG_DEBUG("Received sprite magnification for sprite " << id << " mx=" << asic.sprites_mag_x[id] << ", my=" << asic.sprites_mag_y[id]);
             // Write-only: does not affect pbRegisterPage
             return false;
          default:
@@ -258,14 +259,14 @@ bool asic_register_page_write(word addr, byte val) {
       int colour = (addr & 0x3F) >> 1;
       if ((addr % 2) == 1) {
          double green = static_cast<double>(val & 0x0F)/16;
-         //LOG_DEBUG("Received color operation: color " << colour << " has green = " << green);
+         LOG_DEBUG("Received color operation: color " << colour << " has green = " << green);
          asic_colours[colour][1] = green;
          pbRegisterPage[(addr & 0x3FFF)] = (val & 0x0F);
          // TODO: find a cleaner way to do this - this is a copy paste from "Set ink value" in cap32.cpp
       } else {
          double red   = static_cast<double>((val & 0xF0) >> 4)/16;
          double blue  = static_cast<double>(val & 0x0F)/16;
-         //LOG_DEBUG("Received color operation: color " << colour << " has red = " << red << " and blue = " << blue);
+         LOG_DEBUG("Received color operation: color " << colour << " has red = " << red << " and blue = " << blue);
          asic_colours[colour][0] = red;
          asic_colours[colour][2] = blue;
          pbRegisterPage[(addr & 0x3FFF)] = val;

--- a/src/asic.cpp
+++ b/src/asic.cpp
@@ -210,7 +210,7 @@ bool asic_register_page_write(word addr, byte val) {
          color += 16;
       }
       asic.sprites[id][x][y] = color;
-      LOG_DEBUG("Received sprite data for sprite " << id << ": x=" << x << ", y=" << y << ", color=" << static_cast<int>(val));
+      //LOG_DEBUG("Received sprite data for sprite " << id << ": x=" << x << ", y=" << y << ", color=" << static_cast<int>(val));
    } else if (addr >= 0x6000 && addr < 0x607D) {
       int id = ((addr - 0x6000) >> 3);
       int type = (addr & 0x7);
@@ -218,28 +218,28 @@ bool asic_register_page_write(word addr, byte val) {
          case 0:
             // X position
             asic.sprites_x[id] = (asic.sprites_x[id] & 0xFF00) | val;
-            LOG_DEBUG("Received sprite X for sprite " << id << " x=" << asic.sprites_x[id]);
+            //LOG_DEBUG("Received sprite X for sprite " << id << " x=" << asic.sprites_x[id]);
             // Mirrored in RAM image 4 bytes after
             pbRegisterPage[(addr & 0x3FFF) + 4] = val;
             break;
          case 1:
             // X position
             asic.sprites_x[id] = (asic.sprites_x[id] & 0x00FF) | (val << 8);
-            LOG_DEBUG("Received sprite X for sprite " << id << " x=" << asic.sprites_x[id]);
+            //LOG_DEBUG("Received sprite X for sprite " << id << " x=" << asic.sprites_x[id]);
             // Mirrored in RAM image 4 bytes after
             pbRegisterPage[(addr & 0x3FFF) + 4] = val;
             break;
          case 2:
             // Y position
             asic.sprites_y[id] = ((asic.sprites_y[id] & 0xFF00) | val);
-            LOG_DEBUG("Received sprite Y for sprite " << id << " y=" << asic.sprites_y[id]);
+            //LOG_DEBUG("Received sprite Y for sprite " << id << " y=" << asic.sprites_y[id]);
             // Mirrored in RAM image 4 bytes after
             pbRegisterPage[(addr & 0x3FFF) + 4] = val;
             break;
          case 3:
             // Y position
             asic.sprites_y[id] = ((asic.sprites_y[id] & 0x00FF) | (val << 8));
-            LOG_DEBUG("Received sprite Y for sprite " << id << " y=" << asic.sprites_y[id]);
+            //LOG_DEBUG("Received sprite Y for sprite " << id << " y=" << asic.sprites_y[id]);
             // Affect RAM image
             // Mirrored in RAM image 4 bytes after
             pbRegisterPage[(addr & 0x3FFF) + 4] = val;
@@ -248,11 +248,11 @@ bool asic_register_page_write(word addr, byte val) {
             // Magnification
             asic.sprites_mag_x[id] = decode_magnification(val >> 2);
             asic.sprites_mag_y[id] = decode_magnification(val);
-            LOG_DEBUG("Received sprite magnification for sprite " << id << " mx=" << asic.sprites_mag_x[id] << ", my=" << asic.sprites_mag_y[id]);
+            //LOG_DEBUG("Received sprite magnification for sprite " << id << " mx=" << asic.sprites_mag_x[id] << ", my=" << asic.sprites_mag_y[id]);
             // Write-only: does not affect pbRegisterPage
             return false;
          default:
-            LOG_DEBUG("Received sprite operation of unsupported type: " << type << " addr=" << std::hex << addr << " - val=" << static_cast<int>(val) << std::dec);
+            //LOG_DEBUG("Received sprite operation of unsupported type: " << type << " addr=" << std::hex << addr << " - val=" << static_cast<int>(val) << std::dec);
             break;
       }
    } else if (addr >= 0x6400 && addr < 0x6440) {

--- a/src/asic.cpp
+++ b/src/asic.cpp
@@ -252,21 +252,21 @@ bool asic_register_page_write(word addr, byte val) {
             // Write-only: does not affect pbRegisterPage
             return false;
          default:
-            //LOG_DEBUG("Received sprite operation of unsupported type: " << type << " addr=" << std::hex << addr << " - val=" << static_cast<int>(val) << std::dec);
+            LOG_DEBUG("Received sprite operation of unsupported type: " << type << " addr=" << std::hex << addr << " - val=" << static_cast<int>(val) << std::dec);
             break;
       }
    } else if (addr >= 0x6400 && addr < 0x6440) {
       int colour = (addr & 0x3F) >> 1;
       if ((addr % 2) == 1) {
          double green = static_cast<double>(val & 0x0F)/16;
-         LOG_DEBUG("Received color operation: color " << colour << " has green = " << green);
+         //LOG_DEBUG("Received color operation: color " << colour << " has green = " << green);
          asic_colours[colour][1] = green;
          pbRegisterPage[(addr & 0x3FFF)] = (val & 0x0F);
          // TODO: find a cleaner way to do this - this is a copy paste from "Set ink value" in cap32.cpp
       } else {
          double red   = static_cast<double>((val & 0xF0) >> 4)/16;
          double blue  = static_cast<double>(val & 0x0F)/16;
-         LOG_DEBUG("Received color operation: color " << colour << " has red = " << red << " and blue = " << blue);
+         //LOG_DEBUG("Received color operation: color " << colour << " has red = " << red << " and blue = " << blue);
          asic_colours[colour][0] = red;
          asic_colours[colour][2] = blue;
          pbRegisterPage[(addr & 0x3FFF)] = val;

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -45,6 +45,7 @@
 #include "CapriceGui.h"
 #include "CapriceGuiView.h"
 #include "CapriceVKeyboardView.h"
+#include "CapriceLeavingWithoutSavingView.h"
 
 #include "errors.h"
 #include "log.h"
@@ -1821,94 +1822,81 @@ bool saveConfiguration (t_CPC &CPC, const std::string& configFilename)
 
 
 
-void doCleanUp ()
+SDL_Surface* prepareShowUI()
 {
-   printer_stop();
-   emulator_shutdown();
+   audio_pause();
+   CPC.scr_gui_is_currently_on = true;
+   SDL_ShowCursor(SDL_ENABLE);
+   // guiBackSurface will allow the GUI to capture the current frame
+   SDL_Surface* guiBackSurface(SDL_CreateRGBSurface(SDL_SWSURFACE, back_surface->w, back_surface->h, 32, 0x000000FF, 0x0000FF00, 0x00FF0000, 0x00000000));
+   SDL_BlitSurface(back_surface, nullptr, guiBackSurface, nullptr);
+   return guiBackSurface;
+}
 
-   dsk_eject(&driveA);
-   dsk_eject(&driveB);
-   tape_eject();
+void cleanupShowUI(SDL_Surface* guiBackSurface)
+{
+   SDL_FreeSurface(guiBackSurface);
+   // Clear SDL surface:
+   SDL_FillRect(back_surface, nullptr, SDL_MapRGB(back_surface->format, 0, 0, 0));
+   SDL_ShowCursor(SDL_DISABLE);
+   CPC.scr_gui_is_currently_on = false;
+   audio_resume();
+}
 
-   joysticks_shutdown();
-   audio_shutdown();
-   video_shutdown();
-
-   #ifdef DEBUG
-   if(pfoDebug) {
-     fclose(pfoDebug);
+bool userConfirmsQuitWithoutSaving()
+{
+   auto guiBackSurface = prepareShowUI();
+   bool confirmed = false;
+   // Show warning
+   try {
+      CapriceGui capriceGui;
+      capriceGui.Init();
+      CapriceLeavingWithoutSavingView capriceLeavingWarning(back_surface, guiBackSurface, CRect(0, 0, back_surface->w, back_surface->h));
+      capriceGui.SetMouseVisibility(true);
+      capriceGui.Exec();
+      confirmed = capriceLeavingWarning.Confirmed();
+   } catch(wGui::Wg_Ex_App& e) {
+      // TODO: improve: this is pretty silent if people don't look at the console
+      std::cout << "Failed displaying the leaving without saving dialog: " << e.what() << std::endl;
    }
-   #endif
-
-   SDL_Quit();
+   cleanupShowUI(guiBackSurface);
+   return confirmed;
 }
 
-void cleanExit(int returnCode)
-{
-    doCleanUp();
-    exit(returnCode);
-}
-
-// TODO: Deduplicate showVKeyboard and showGui
 void showVKeyboard()
 {
-  // Activate virtual keyboard
-  audio_pause();
-  CPC.scr_gui_is_currently_on = true;
-  SDL_ShowCursor(SDL_ENABLE);
-  // guiBackSurface will allow the GUI to capture the current frame
-  SDL_Surface* guiBackSurface(SDL_CreateRGBSurface(SDL_SWSURFACE, back_surface->w, back_surface->h, 32, 0x000000FF, 0x0000FF00, 0x00FF0000, 0x00000000));
-  SDL_BlitSurface(back_surface, nullptr, guiBackSurface, nullptr);
-  try {
-    CapriceGui capriceGui;
-    capriceGui.Init();
-    CapriceVKeyboardView capriceVKeyboardView(back_surface, guiBackSurface, CRect(0, 0, back_surface->w, back_surface->h));
-    capriceGui.SetMouseVisibility(true);
-    capriceGui.Exec();
-    auto newEvents = capriceVKeyboardView.GetEvents();
-    virtualKeyboardEvents.splice(virtualKeyboardEvents.end(), newEvents);
-  } catch(wGui::Wg_Ex_App& e) {
-    // TODO: improve: this is pretty silent if people don't look at the console
-    std::cout << "Failed displaying the virtual keyboard: " << e.what() << std::endl;
-  }
-  SDL_FreeSurface(guiBackSurface);
-  // Clear SDL surface:
-  SDL_FillRect(back_surface, nullptr, SDL_MapRGB(back_surface->format, 0, 0, 0));
-  SDL_ShowCursor(SDL_DISABLE);
-  CPC.scr_gui_is_currently_on = false;
-  audio_resume();
+   auto guiBackSurface = prepareShowUI();
+   // Activate virtual keyboard
+   try {
+      CapriceGui capriceGui;
+      capriceGui.Init();
+      CapriceVKeyboardView capriceVKeyboardView(back_surface, guiBackSurface, CRect(0, 0, back_surface->w, back_surface->h));
+      capriceGui.SetMouseVisibility(true);
+      capriceGui.Exec();
+      auto newEvents = capriceVKeyboardView.GetEvents();
+      virtualKeyboardEvents.splice(virtualKeyboardEvents.end(), newEvents);
+   } catch(wGui::Wg_Ex_App& e) {
+      // TODO: improve: this is pretty silent if people don't look at the console
+      std::cout << "Failed displaying the virtual keyboard: " << e.what() << std::endl;
+   }
+   cleanupShowUI(guiBackSurface);
 }
-
-
 
 void showGui()
 {
-  // Activate gui
-  audio_pause();
-  CPC.scr_gui_is_currently_on = true;
-  SDL_ShowCursor(SDL_ENABLE);
-  // guiBackSurface will allow the GUI to capture the current frame
-  SDL_Surface* guiBackSurface(SDL_CreateRGBSurface(SDL_SWSURFACE, back_surface->w, back_surface->h, 32, 0x000000FF, 0x0000FF00, 0x00FF0000, 0x00000000));
-  SDL_BlitSurface(back_surface, nullptr, guiBackSurface, nullptr);
-  try {
-    CapriceGui capriceGui;
-    capriceGui.Init();
-    CapriceGuiView capriceGuiView(back_surface, guiBackSurface, CRect(0, 0, back_surface->w, back_surface->h));
-    capriceGui.SetMouseVisibility(true);
-    capriceGui.Exec();
-  } catch(wGui::Wg_Ex_App& e) {
-    // TODO: improve: this is pretty silent if people don't look at the console
-    std::cout << "Failed displaying the GUI: " << e.what() << std::endl;
-  }
-  SDL_FreeSurface(guiBackSurface);
-  // Clear SDL surface:
-  SDL_FillRect(back_surface, nullptr, SDL_MapRGB(back_surface->format, 0, 0, 0));
-  SDL_ShowCursor(SDL_DISABLE);
-  CPC.scr_gui_is_currently_on = false;
-  audio_resume();
+   auto guiBackSurface = prepareShowUI();
+   try {
+      CapriceGui capriceGui;
+      capriceGui.Init();
+      CapriceGuiView capriceGuiView(back_surface, guiBackSurface, CRect(0, 0, back_surface->w, back_surface->h));
+      capriceGui.SetMouseVisibility(true);
+      capriceGui.Exec();
+   } catch(wGui::Wg_Ex_App& e) {
+      // TODO: improve: this is pretty silent if people don't look at the console
+      std::cout << "Failed displaying the GUI: " << e.what() << std::endl;
+   }
+   cleanupShowUI(guiBackSurface);
 }
-
-
 
 void set_osd_message(const std::string& message) {
    osd_timing = SDL_GetTicks() + 1000;
@@ -1950,10 +1938,44 @@ void dumpSnapshot() {
    }
 }
 
+bool driveAltered() {
+  return driveA.altered || driveB.altered;
+}
+
+void doCleanUp ()
+{
+   printer_stop();
+   emulator_shutdown();
+
+   dsk_eject(&driveA);
+   dsk_eject(&driveB);
+   tape_eject();
+
+   joysticks_shutdown();
+   audio_shutdown();
+   video_shutdown();
+
+   #ifdef DEBUG
+   if(pfoDebug) {
+     fclose(pfoDebug);
+   }
+   #endif
+
+   SDL_Quit();
+}
+
+void cleanExit(int returnCode, bool askIfUnsaved)
+{
+   if (askIfUnsaved && driveAltered() && !userConfirmsQuitWithoutSaving()) {
+     return;
+   }
+   doCleanUp();
+   exit(returnCode);
+}
+
 int cap32_main (int argc, char **argv)
 {
    int iExitCondition;
-   bool bolDone;
    bool take_screenshot = false;
    SDL_Event event;
    std::vector<std::string> slot_list;
@@ -2032,9 +2054,8 @@ int cap32_main (int argc, char **argv)
    audio_resume();
 
    iExitCondition = EC_FRAME_COMPLETE;
-   bolDone = false;
 
-   while (!bolDone) {
+   while (true) {
       if(!virtualKeyboardEvents.empty()
          && (nextVirtualEventFrameCount < dwFrameCountOverall)
          && (breakPointsToSkipBeforeProceedingWithVirtualEvents == 0)) {
@@ -2366,6 +2387,6 @@ int cap32_main (int argc, char **argv)
       }
    }
 
-   exit(0);
+   return 0;
 }
 

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -381,6 +381,7 @@ typedef struct {
 } t_VDU;
 
 // cap32.cpp
+bool driveAltered();
 void emulator_reset(bool bolMF2Reset);
 int  emulator_init();
 int  video_set_palette();
@@ -394,7 +395,7 @@ void audio_pause ();
 void audio_resume ();
 int video_init ();
 void video_shutdown ();
-void cleanExit(int returnCode);
+void cleanExit(int returnCode, bool askIfUnsaved = true);
 
 // Return the path to the best (i.e: most specific) configuration file.
 // Priority order is:

--- a/src/disk.h
+++ b/src/disk.h
@@ -96,7 +96,7 @@ struct t_drive {
    unsigned int sides; // total number of sides
    unsigned int current_side; // side being accessed
    unsigned int current_sector; // sector being accessed
-   unsigned int altered; // has the image been modified?
+   bool altered; // has the image been modified?
    unsigned int write_protected; // is the image write protected?
    unsigned int random_DEs; // sectors with Data Errors return random data?
    unsigned int flipped; // reverse the side to access?

--- a/src/fdc.cpp
+++ b/src/fdc.cpp
@@ -541,7 +541,7 @@ void fdc_write_data(byte val)
                   memcpy(&FDC.result[RES_C], pbPtr, 4); // copy sector's CHRN to result buffer
                   FDC.result[RES_N] = FDC.command[CMD_C]; // overwrite with the N value from the writeID command
 
-                  active_drive->altered = 1; // indicate that the image has been modified
+                  active_drive->altered = true; // indicate that the image has been modified
                   FDC.phase = RESULT_PHASE; // switch to result phase
                }
                else if (FDC.command[CMD_R] != FDC.command[CMD_EOT]) { // haven't reached End of Track?
@@ -549,7 +549,7 @@ void fdc_write_data(byte val)
                   cmd_write();
                }
                else {
-                  active_drive->altered = 1; // indicate that the image has been modified
+                  active_drive->altered = true; // indicate that the image has been modified
 
                   FDC.result[RES_ST0] |= 0x40; // AT
                   FDC.result[RES_ST1] |= 0x80; // End of Cylinder
@@ -851,9 +851,11 @@ void fdc_write()
          FDC.phase = RESULT_PHASE; // switch to result phase
       }
       else if (active_track->sectors != 0) { // track is formatted?
+         active_drive->altered = true;
          cmd_write();
       }
       else { // unformatted track
+         active_drive->altered = true;
          FDC.result[RES_ST0] |= 0x40; // AT
          FDC.result[RES_ST1] |= 0x01; // Missing AM
 
@@ -958,6 +960,7 @@ void fdc_writeID()
          FDC.phase = RESULT_PHASE; // switch to result phase
       }
       else {
+         active_drive->altered = true;
          FDC.buffer_count = FDC.command[CMD_H] << 2; // number of sectors * 4 = number of bytes still outstanding
          FDC.buffer_ptr = pbGPBuffer; // buffer to temporarily hold the track format
          FDC.buffer_endptr = pbGPBuffer + FDC.buffer_count;

--- a/src/gui/includes/CapriceLeavingWithoutSavingView.h
+++ b/src/gui/includes/CapriceLeavingWithoutSavingView.h
@@ -1,0 +1,25 @@
+#ifndef _WG_CAPRICELEAVINGWITHOUTSAVINGVIEW_H_
+#define _WG_CAPRICELEAVINGWITHOUTSAVINGVIEW_H_
+
+#include "wgui.h"
+#include "wg_messagebox.h"
+
+using namespace wGui;
+
+class CapriceLeavingWithoutSavingView : public CView
+{
+  protected:
+    wGui::CMessageBox *m_pMessageBox;
+    bool confirmed = false;
+
+  public:
+    CapriceLeavingWithoutSavingView(SDL_Surface* surface, SDL_Surface* backSurface, const CRect& WindowRect);
+
+    bool Confirmed();
+
+    void PaintToSurface(SDL_Surface& ScreenSurface, SDL_Surface& FloatingSurface, const CPoint& Offset) const override;
+
+    bool HandleMessage(CMessage* pMessage) override;
+};
+
+#endif

--- a/src/gui/includes/CapriceMenu.h
+++ b/src/gui/includes/CapriceMenu.h
@@ -49,6 +49,7 @@ namespace wGui
     protected:
       std::list<CapriceGuiViewButton> m_buttons;
       SDL_Surface *m_pScreenSurface;
+      bool m_confirmed_quit = false;
       
       CapriceMenu(const CapriceMenu&) = delete;
       CapriceMenu& operator=(const CapriceMenu&) = delete;

--- a/src/gui/includes/CapriceVKeyboardView.h
+++ b/src/gui/includes/CapriceVKeyboardView.h
@@ -1,3 +1,6 @@
+#ifndef _WG_CAPRICEVKEYBOARDVIEW_H_
+#define _WG_CAPRICEVKEYBOARDVIEW_H_
+
 #include "wgui.h"
 #include "CapriceVKeyboard.h"
 
@@ -15,3 +18,5 @@ class CapriceVKeyboardView : public CView
 
     void PaintToSurface(SDL_Surface& ScreenSurface, SDL_Surface& FloatingSurface, const CPoint& Offset) const override;
 };
+
+#endif

--- a/src/gui/src/CapriceLeavingWithoutSavingView.cpp
+++ b/src/gui/src/CapriceLeavingWithoutSavingView.cpp
@@ -1,0 +1,68 @@
+#include "CapriceLeavingWithoutSavingView.h"
+
+CapriceLeavingWithoutSavingView::CapriceLeavingWithoutSavingView(SDL_Surface* surface, SDL_Surface* backSurface, const CRect& WindowRect) : CView(surface, backSurface, WindowRect)
+{
+  CMessageServer::Instance().RegisterMessageClient(this, CMessage::CTRL_MESSAGEBOXRETURN);
+  m_pMessageBox = new wGui::CMessageBox(CRect(CPoint(m_ClientRect.Width() /2 - 125, m_ClientRect.Height() /2 - 40), 250, 80), this, nullptr, "Quit without saving?", "Unsaved changes. Do you really want to quit?", CMessageBox::BUTTON_YES | CMessageBox::BUTTON_NO);
+  m_pMessageBox->SetModal(true);
+}
+
+bool CapriceLeavingWithoutSavingView::Confirmed()
+{
+  return confirmed;
+}
+
+void CapriceLeavingWithoutSavingView::PaintToSurface(SDL_Surface& ScreenSurface, SDL_Surface& FloatingSurface, const CPoint& Offset) const
+{
+  if (m_bVisible)
+  {
+    // Reset backgound
+    SDL_BlitSurface(m_pBackSurface, nullptr, &ScreenSurface, nullptr);
+
+    // Draw all child windows recursively
+    for (const auto child : m_ChildWindows)
+    {
+      if (child)
+      {
+        child->PaintToSurface(ScreenSurface, FloatingSurface, Offset);
+      }
+    }
+  }
+}
+
+bool CapriceLeavingWithoutSavingView::HandleMessage(CMessage* pMessage)
+{
+  bool bHandled = false;
+
+  if (pMessage)
+  {
+    switch(pMessage->MessageType())
+    {
+      case CMessage::APP_DESTROY_FRAME:
+        {
+          // Exit gui
+          CMessageServer::Instance().QueueMessage(new CMessage(CMessage::APP_EXIT, nullptr, this));
+          break;
+        }
+
+      case CMessage::CTRL_MESSAGEBOXRETURN:
+        {
+          wGui::CValueMessage<CMessageBox::EButton> *pValueMessage = dynamic_cast<CValueMessage<CMessageBox::EButton>*>(pMessage);
+          if (pValueMessage && pValueMessage->Value() == CMessageBox::BUTTON_YES)
+          {
+            confirmed = true;
+          }
+          // Exit gui
+          CMessageServer::Instance().QueueMessage(new CMessage(CMessage::APP_EXIT, nullptr, this));
+          break;
+        }
+
+      default :
+        break;
+    }
+  }
+  if (!bHandled) {
+    bHandled = CView::HandleMessage(pMessage);
+  }
+  return bHandled;
+}

--- a/src/gui/src/CapriceVKeyboardView.cpp
+++ b/src/gui/src/CapriceVKeyboardView.cpp
@@ -1,6 +1,3 @@
-#ifndef _WG_CAPRICEVKEYBOARDVIEW_H_
-#define _WG_CAPRICEVKEYBOARDVIEW_H_
-
 #include "CapriceVKeyboardView.h"
 
 CapriceVKeyboardView::CapriceVKeyboardView(SDL_Surface* surface, SDL_Surface* backSurface, const CRect& WindowRect) : CView(surface, backSurface, WindowRect)
@@ -30,5 +27,3 @@ void CapriceVKeyboardView::PaintToSurface(SDL_Surface& ScreenSurface, SDL_Surfac
     }
   }
 }
-
-#endif

--- a/src/ipf.cpp
+++ b/src/ipf.cpp
@@ -392,7 +392,7 @@ void ipf_eject_hook (t_drive *drive)
 	_CAPSRemImage(id);
 	_CAPSExit();
 	unload_caps_library();
-	drive->altered = 0; // discard modifications
+	drive->altered = false; // discard modifications
 	drive->eject_hook = nullptr;
 }
 
@@ -501,7 +501,7 @@ int ipf_load (const std::string &filename, t_drive *drive)
 	// Set up the internal drive details
 	drive->tracks = cii.maxcylinder+1;
 	drive->sides = cii.maxhead;
-	drive->altered = 0;
+	drive->altered = false;
 	drive->track_hook = ipf_track_hook;
 	drive->eject_hook = ipf_eject_hook;
 

--- a/src/slotshandler.cpp
+++ b/src/slotshandler.cpp
@@ -525,7 +525,7 @@ int dsk_load (FILE *pfile, t_drive *drive)
         }
       }
     }
-    drive->altered = 0; // disk is as yet unmodified
+    drive->altered = false; // disk is as yet unmodified
   } else {
     if (memcmp(pbPtr, "EXTENDED", 8) == 0) { // extended DSK image?
       LOG_DEBUG("Loading extended disk");
@@ -601,7 +601,7 @@ int dsk_load (FILE *pfile, t_drive *drive)
           }
         }
       }
-      drive->altered = 0; // disk is as yet unmodified
+      drive->altered = false; // disk is as yet unmodified
     } else {
       LOG_ERROR("Unknown DSK type");
       dsk_eject(drive);
@@ -685,6 +685,7 @@ int dsk_save (const std::string &filename, t_drive *drive)
             }
          }
       }
+      drive->altered = false;  // Drive is not modified anymore
       fclose(pfileObject);
    } else {
       return ERR_DSK_WRITE; // write attempt failed
@@ -738,7 +739,7 @@ int dsk_format (t_drive *drive, int iFormat)
          memset(pbTempPtr, disk_format[iFormat].filler_byte, dwTrackSize);
       }
    }
-   drive->altered = 1; // flag disk as having been modified
+   drive->altered = true; // flag disk as having been modified
 
 exit:
    if (iRetCode != 0) { // on error, 'eject' disk from drive


### PR DESCRIPTION
This verifies whether a change has been made to driveA or driveB (the
only slots in which we support saving for now) and warns if leaving
without having saved.

This solves #105 