### PR TITLE
clang build fix proposal.

### DIFF
--- a/makefile
+++ b/makefile
@@ -105,10 +105,16 @@ TEST_OBJECTS:=$(TEST_DEPENDS:.d=.o)
 
 .PHONY: all check_deps clean deb_pkg debug debug_flag distrib doc unit_test install
 
-WARNINGS = -Wall -Wextra -Wzero-as-null-pointer-constant -Wformat=2 -Wold-style-cast -Wmissing-include-dirs -Wlogical-op -Woverloaded-virtual -Wpointer-arith -Wredundant-decls
+WARNINGS = -Wall -Wextra -Wzero-as-null-pointer-constant -Wformat=2 -Wold-style-cast -Wmissing-include-dirs -Woverloaded-virtual -Wpointer-arith -Wredundant-decls
 COMMON_CFLAGS += $(CFLAGS) -std=c++17 $(IPATHS)
 DEBUG_FLAGS = -Werror -g -O0 -DDEBUG
-RELEASE_FLAGS = -O2 -funroll-loops -ffast-math -fomit-frame-pointer -fno-strength-reduce -finline-functions -s
+RELEASE_FLAGS = -O2 -funroll-loops -ffast-math -fomit-frame-pointer -finline-functions -s
+
+ifeq ($(findstring "g++",$(CXX)),"g++")
+WARNINGS += -Wlogical-op
+RELEASE_FLAGS += -fno-strength-reduce
+endif
+
 BUILD_FLAGS = $(RELEASE_FLAGS)
 
 debug: BUILD_FLAGS:=$(DEBUG_FLAGS)


### PR DESCRIPTION
remove few spurious warnings at build time with unsupported gnu gcc flags.