### PR TITLE
Following up on previous PR, suppressing warning with clang with gcc_…

### DIFF
--- a/src/cap32.h
+++ b/src/cap32.h
@@ -85,6 +85,13 @@ class InputMapper;
 
 #define DEFAULT_VIDEO_PLUGIN 0
 
+#ifdef _WIN32
+// As opposed to ms_struct, needs to be explicit on Windows
+#define ATTR_PACKED __attribute__((packed, gcc_struct))
+#else
+#define ATTR_PACKED __attribute__((packed))
+#endif
+
 typedef struct {
    char id[8];
    char unused1[8];
@@ -367,7 +374,7 @@ typedef struct {
          unsigned char _noise, _mixer, _ampa, _ampb, _ampc;
          unsigned short Envelope;
          unsigned char _envtype, _porta, portb;
-      } __attribute__((packed, gcc_struct));
+      } ATTR_PACKED;
    } RegisterAY;
    int AmplitudeEnv;
    bool FirstPeriod;


### PR DESCRIPTION
…struct

 here on unix. Anyway it is important on Windows to avoid surprises with struct
 layout differences.