### PR TITLE
Fix a bug on case-sensitve filesystems when loading .zip.

### DIFF
--- a/src/slotshandler.cpp
+++ b/src/slotshandler.cpp
@@ -1373,7 +1373,7 @@ int file_load(const std::string& filepath, const DRIVE drive)
 
     std::string filename = zip_info.filesOffsets[0].first;
     pos = filename.length() - 4;
-    extension = filename.substr(pos); // grab the extension
+    extension = stringutils::lower(filename.substr(pos)); // grab the extension in lowercases
     LOG_DEBUG("Extracting " << filepath << ", " << filename << ", " << extension);
     file = extractFile(filepath, filename, extension);
   }


### PR DESCRIPTION
Before the fix, .zip files containing .DSK could not be loaded,
as suffix '.DSK' was compared to '.dsk' resulting in the following error:

ERROR   src/slotshandler.cpp:1389 - File format unsupported for <file>.zip