### PR TITLE
Update man page, html help and the -h section to update it all to current parameters

### DIFF
--- a/doc/man.html
+++ b/doc/man.html
@@ -1,5 +1,5 @@
-<!-- Creator     : groff version 1.22.3 -->
-<!-- CreationDate: Fri Jun  9 09:16:47 2017 -->
+<!-- Creator     : groff version 1.22.4 -->
+<!-- CreationDate: Sat Oct  7 02:26:21 2023 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -100,20 +100,26 @@ configuration file was specified using the <b>--cfg_file</b>
 command line switch, Caprice32 will try and use it. If no
 configuration file was specified, or the configuration file
 specified does not exist, Caprice32 will try and open, in
-this order: <b>$CWD/cap32.cfg</b> ($CWD being the directory
-where the cap32 executable resides), then a
-<b>.cap32.cfg</b> file in the user home directory, then
-<b>/etc/cap32.cfg</b>. Caprice32 will use the first valid
-file it finds. If no configuration file is found, a default
-configuration will be used.</p>
+this order: <br>
+- <b>$CWD/cap32.cfg</b> ($CWD being the directory where the
+cap32 executable resides) <br>
+- <b>cap32.cfg</b> file in the location pointed to by the
+XDG_CONFIG_HOME environment variable. If XDG_CONFIG_HOME is
+undefined, it will look at $HOME/.config/ as default
+XDG_CONFIG_HOME directory. <br>
+- <b>$HOME/.cap32.cfg</b> for compatibility. <br>
+- <b>/etc/cap32.cfg</b>. <br>
+Caprice32 will use the first valid file it finds. If no
+configuration file is found, a default configuration will be
+used.</p>
 
 <p style="margin-left:22%; margin-top: 1em">The
 configuration file contains various configuration
 parameters, some of which can be modified from the GUI. When
 saving the configuration from the GUI, it will be written in
-the configuration file specified by the <b>--cfg_file</b>
-switch, if it exists, else in $CWD/cap32.cfg if it exists,
-otherwise in $HOME/.cap32.cfg.</p>
+the configuration file following the same order than
+previously described, except for the addition of the write
+permission condition.</p>
 
 <p style="margin-left:22%; margin-top: 1em">Most of the
 configuration file entries are commented in the
@@ -208,6 +214,29 @@ configuration file.</p>
 
 <p style="margin-left:22%;">display short help and
 exits</p>
+
+<p style="margin-left:11%;"><b>-i</b>, <b>--inject</b></p>
+
+<p style="margin-left:22%;">inject a binary in memory after
+the CPC startup finishes</p>
+
+<p style="margin-left:11%;"><b>-o</b>, <b>--offset</b></p>
+
+<p style="margin-left:22%;">offset at which to inject the
+binary provided with -i (default: 0x6000)</p>
+
+<p style="margin-left:11%;"><b>-O</b>,
+<b>--override</b></p>
+
+<p style="margin-left:22%;">override an option from the
+config. Can be repeated. (example: -O system.model=3)</p>
+
+<p style="margin-left:11%;"><b>-s</b>,
+<b>--sym_file</b>=<i>file</i></p>
+
+<p style="margin-left:22%;">use &lt;file&gt; as a source of
+symbols and entry points for disassembling in
+developers&rsquo; tools.</p>
 
 <p style="margin-left:11%;"><b>-V</b>, <b>--version</b></p>
 

--- a/doc/man6/cap32.6
+++ b/doc/man6/cap32.6
@@ -26,13 +26,13 @@ The \fBrom_path\fR entry in the configuration file is used by the emulator to fi
 .PP
 \fBConfiguration\fR
 .RS
-When launched, Caprice32 will look for a configuration file in several locations. If a configuration file was specified using the \fB\-\-cfg_file\fR command line switch, Caprice32 will try and use it. If no configuration file was specified, or the configuration file specified does not exist, Caprice32 will try and open, in this order: 
+When launched, Caprice32 will look for a configuration file in several locations. If a configuration file was specified using the \fB\-\-cfg_file\fR command line switch, Caprice32 will try and use it. If no configuration file was specified, or the configuration file specified does not exist, Caprice32 will try and open, in this order:
 .br
   - \fB$CWD/cap32.cfg\fR ($CWD being the directory where the cap32 executable resides)
 .br
   - \fBcap32.cfg\fR file in the location pointed to by the XDG_CONFIG_HOME environment variable. If XDG_CONFIG_HOME is undefined, it will look at $HOME/.config/ as default XDG_CONFIG_HOME directory.
 .br
-  - \fB$HOME/.cap32.cfg\fR for compatibility. 
+  - \fB$HOME/.cap32.cfg\fR for compatibility.
 .br
   - \fB/etc/cap32.cfg\fR.
 .br
@@ -120,6 +120,18 @@ use FILE as the emulator configuration file.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 display short help and exits
+.TP
+\fB\-i\fR, \fB\-\-inject\fR
+inject a binary in memory after the CPC startup finishes
+.TP
+\fB\-o\fR, \fB\-\-offset\fR
+offset at which to inject the binary provided with -i (default: 0x6000)
+.TP
+\fB\-O\fR, \fB\-\-override\fR
+override an option from the config. Can be repeated. (example: -O system.model=3)
+.TP
+\fB\-s\fR, \fB\-\-sym_file\fR=\fIfile\fR
+use <file> as a source of symbols and entry points for disassembling in developers' tools.
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 display Caprice32 version and exits

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -38,9 +38,9 @@ void usage(std::ostream &os, char *progPath, int errcode)
    os << "   -a/--autocmd=<command>: execute command as soon as the emulator starts.\n";
    os << "   -c/--cfg_file=<file>:   use <file> as the emulator configuration file instead of the default.\n";
    os << "   -h/--help:              shows this help\n";
-   os << "   -i/--inject:            inject a binary in memory after the CPC startup finishes\n";
-   os << "   -o/--offset:            offset at which to inject the binary provided with -i (default: 0x6000)\n";
-   os << "   -O/--override:          override an option from the config. Can be repeated. (example: -o system.model=3)\n";
+   os << "   -i/--inject=<file>:     inject a binary in memory after the CPC startup finishes\n";
+   os << "   -o/--offset <address>:  offset at which to inject the binary provided with -i (default: 0x6000)\n";
+   os << "   -O/--override:          override an option from the config. Can be repeated. (example: -O system.model=3)\n";
    os << "   -s/--sym_file=<file>:   use <file> as a source of symbols and entry points for disassembling in developers' tools.\n";
    os << "   -V/--version:           outputs version and exit\n";
    os << "   -v/--verbose:           be talkative\n";
@@ -189,7 +189,7 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
 #ifdef DEBUG
                       << " DEBUG"
 #endif
-#ifdef	WITH_IPF 
+#ifdef	WITH_IPF
                       << " WITH_IPF"
 #endif
                       << "\n";
@@ -211,4 +211,3 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
    slot_list.assign(argv+optind, argv+argc);
    LOG_DEBUG("slot_list: " << stringutils::join(slot_list, ","))
 }
-

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -39,7 +39,7 @@ void usage(std::ostream &os, char *progPath, int errcode)
    os << "   -c/--cfg_file=<file>:   use <file> as the emulator configuration file instead of the default.\n";
    os << "   -h/--help:              shows this help\n";
    os << "   -i/--inject=<file>:     inject a binary in memory after the CPC startup finishes\n";
-   os << "   -o/--offset <address>:  offset at which to inject the binary provided with -i (default: 0x6000)\n";
+   os << "   -o/--offset=<address>:  offset at which to inject the binary provided with -i (default: 0x6000)\n";
    os << "   -O/--override:          override an option from the config. Can be repeated. (example: -O system.model=3)\n";
    os << "   -s/--sym_file=<file>:   use <file> as a source of symbols and entry points for disassembling in developers' tools.\n";
    os << "   -V/--version:           outputs version and exit\n";


### PR DESCRIPTION
The man page, the html manual and cap32 -h help files were all in need of updating.

The man page/html help file didn't have anything around the more recently added command line parameters.

cap32 -h needed updating to reflect that --inject took a filename, --offset took an address, and corrected an error in the example of --override (it used a lowercase o and should have been uppercase)