### PR TITLE
Fix a bug when loading .zip from the command line.

### DIFF
--- a/src/slotshandler.cpp
+++ b/src/slotshandler.cpp
@@ -151,7 +151,7 @@ void fillSlots (std::vector<std::string> slot_list, t_CPC& CPC)
            }
            std::string filename = zip_info.filesOffsets[0].first;
            pos = filename.length() - 4;
-           extension = filename.substr(pos); // grab the extension
+           extension = stringutils::lower(filename.substr(pos)); // grab the extension
          }
 
          if (fillSlot(CPC.driveA, have_DSKA, fullpath, extension, ".dsk", "drive A disk"))


### PR DESCRIPTION
Before the fix, .zip files containing e.g. [NAME].DSK are not loaded,
as suffix '.DSK' was compared to '.dsk' inside function 'fillSlot',
resulting in aborting the load operation.