### PR TITLE
Adding net4cpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Caprice32 provides:
   * Custom disk formats
   * Printer support
   * Experimental support of Multiface 2 (you should prefer using memory tool)
+  * Net4CPC (W5100S Ethernet) emulation — TCP and UDP sockets backed by host POSIX sockets
 
 You see something missing ? Do not hesitate to open an issue to suggest it.
 
@@ -115,6 +116,49 @@ I encourage you to get involved in the project.
 # Comments or ready to contribute?
 
 If you have suggestions, a bug report or even want to participate to the development, please feel free to open an issue or submit a pull request.
+
+# Net4CPC Ethernet emulation
+
+This fork adds emulation of the [Net4CPC](https://github.com/salvogendut/net4cpc) expansion board, which connects a WIZnet W5100S Ethernet controller to the CPC expansion bus.
+
+## Enabling it
+
+Open the emulator menu (F1) → **Options** → **General** tab → tick **Enable Net4CPC ethernet emulation**. The setting is saved in `cap32.cfg` as `net4cpc=1`.
+
+## How it works
+
+The W5100S is accessed through four Z80 I/O ports using the chip's indirect parallel-bus protocol:
+
+| Port   | Name    | Role |
+|--------|---------|------|
+| 0xFD20 | MR      | Mode Register — returns 0x03 (chip present, auto-increment on) |
+| 0xFD21 | IDM_ARH | High byte of 16-bit indirect address |
+| 0xFD22 | IDM_ARL | Low byte of 16-bit indirect address |
+| 0xFD23 | IDM_DR  | Data register — address auto-increments after each access |
+
+The full 64 KB W5100S register space is emulated in software:
+
+| Range          | Contents |
+|----------------|----------|
+| 0x0000–0x002F  | Common registers (MR, GAR, SUBR, SHAR, SIPR, …) |
+| 0x0400–0x07FF  | Socket 0–3 registers (256 bytes each) |
+| 0x4000–0x5FFF  | TX ring buffers (2 KB per socket) |
+| 0x6000–0x7FFF  | RX ring buffers (2 KB per socket) |
+
+Socket commands (OPEN, CONNECT, SEND, RECV, CLOSE, …) are intercepted and mapped to host POSIX sockets — TCP via `SOCK_STREAM`, UDP via `SOCK_DGRAM`. All sockets are non-blocking; connection completion and incoming data are detected lazily when the CPC firmware reads the socket status or RX size registers.
+
+For UDP receive, the emulator prepends the standard W5100S 8-byte header to each datagram in the RX ring buffer (4 bytes source IP + 2 bytes source port + 2 bytes payload length), matching the behaviour expected by W5100S firmware such as the Net4CPC DNS library.
+
+## Source IP binding (SIPR)
+
+When the CPC firmware writes its desired IP address into the W5100S SIPR registers (0x000F–0x0012) and issues an OPEN command, the emulator calls `bind()` on the host socket to that address. This allows the emulated CPC to appear on the local network under its own IP, provided that IP is assigned to a host interface. If the bind fails the socket falls back to the host's default IP silently.
+
+## Limitations
+
+- No hardware interrupts (IR pin) — firmware must poll Sn_SR / Sn_RX_RSR.
+- TCP listen / server-side accept is not implemented.
+- ICMP (ping) is not emulated.
+- The emulation is only available on Linux/macOS builds (uses POSIX socket APIs).
 
 # Why another GitHub repository ?
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ When the CPC firmware writes its desired IP address into the W5100S SIPR registe
 - No hardware interrupts (IR pin) — firmware must poll Sn_SR / Sn_RX_RSR.
 - TCP listen / server-side accept is not implemented.
 - ICMP (ping) is not emulated.
-- The emulation is only available on Linux/macOS builds (uses POSIX socket APIs).
+- Windows is not supported — the implementation uses POSIX socket APIs (`<sys/socket.h>`, `fcntl`, etc.) which are not available on Windows.
 
 # Why another GitHub repository ?
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you have suggestions, a bug report or even want to participate to the develop
 
 # Net4CPC Ethernet emulation
 
-This fork adds emulation of the [Net4CPC](https://github.com/salvogendut/net4cpc) expansion board, which connects a WIZnet W5100S Ethernet controller to the CPC expansion bus.
+This fork adds emulation of the [Net4CPC](https://github.com/salafek/Net4CPC) expansion board, which connects a WIZnet W5100S Ethernet controller to the CPC expansion bus.
 
 ## Enabling it
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ When the CPC firmware writes its desired IP address into the W5100S SIPR registe
 - No hardware interrupts (IR pin) — firmware must poll Sn_SR / Sn_RX_RSR.
 - TCP listen / server-side accept is not implemented.
 - ICMP (ping) is not emulated.
-- Windows is not supported — the implementation uses POSIX socket APIs (`<sys/socket.h>`, `fcntl`, etc.) which are not available on Windows.
+- Windows support is untested. The socket layer uses `#ifdef _WIN32` to select Winsock2 vs POSIX APIs, but the Windows build path has not been verified.
 
 # Why another GitHub repository ?
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you have suggestions, a bug report or even want to participate to the develop
 
 # Net4CPC Ethernet emulation
 
-This fork adds emulation of the [Net4CPC](https://github.com/salafek/Net4CPC) expansion board, which connects a WIZnet W5100S Ethernet controller to the CPC expansion bus.
+Caprice32 supports emulation of the [Net4CPC](https://github.com/salafek/Net4CPC) expansion board, which connects a WIZnet W5100S Ethernet controller to the CPC expansion bus.
 
 ## Enabling it
 

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -43,6 +43,7 @@
 #include "argparse.h"
 #include "slotshandler.h"
 #include "fileutils.h"
+#include "net4cpc.h"
 
 #include <errno.h>
 #include <cstring>
@@ -475,6 +476,10 @@ byte z80_IN_handler (reg_pair port)
          }
       }
    }
+// Net4CPC (W5100S) -----------------------------------------------------------
+   else if (CPC.net4cpc && port.b.h == 0xfd) { // Net4CPC chip select?
+      ret_val = net4cpc_in(port.b.l & 0x03);
+   }
    LOG_DEBUG("IN on port " << std::hex << static_cast<int>(port.w.l) << ", ret_val=" << static_cast<int>(ret_val) << std::dec);
    return ret_val;
 }
@@ -856,6 +861,10 @@ void z80_OUT_handler (reg_pair port, byte val)
          ga_memory_manager();
       }
    }
+// Net4CPC (W5100S) -----------------------------------------------------------
+   else if (CPC.net4cpc && port.b.h == 0xfd) { // Net4CPC chip select?
+      net4cpc_out(port.b.l & 0x03, val);
+   }
 }
 
 
@@ -1110,6 +1119,9 @@ void emulator_reset ()
    }
    membank_read[0] = pbROMlo; // 'page in' lower ROM
    membank_read[3] = pbROMhi; // 'page in' upper ROM
+
+// Net4CPC
+   net4cpc_reset();
 
 // Multiface 2
    dwMF2Flags = 0;
@@ -1804,6 +1816,7 @@ void loadConfiguration (t_CPC &CPC, const std::string& configFilename)
    CPC.boot_time = conf.getIntValue("system", "boot_time", 5);
    CPC.printer = conf.getIntValue("system", "printer", 0) & 1;
    CPC.mf2 = conf.getIntValue("system", "mf2", 0) & 1;
+   CPC.net4cpc = conf.getIntValue("system", "net4cpc", 0) & 1;
    CPC.keyboard = conf.getIntValue("system", "keyboard", 0);
    if (CPC.keyboard > MAX_ROM_MODS) {
       CPC.keyboard = 0;
@@ -1906,6 +1919,7 @@ bool saveConfiguration (t_CPC &CPC, const std::string& configFilename)
    conf.setIntValue("system", "auto_pause", CPC.auto_pause);
    conf.setIntValue("system", "printer", CPC.printer);
    conf.setIntValue("system", "mf2", CPC.mf2);
+   conf.setIntValue("system", "net4cpc", CPC.net4cpc);
    conf.setIntValue("system", "keyboard", CPC.keyboard);
    conf.setIntValue("system", "boot_time", CPC.boot_time);
    conf.setIntValue("system", "joystick_emulation", static_cast<int>(CPC.joystick_emulation));

--- a/src/cap32.h
+++ b/src/cap32.h
@@ -209,6 +209,7 @@ class t_CPC {
    unsigned int printer;
    unsigned int printer_port;
    unsigned int mf2;
+   unsigned int net4cpc;
    unsigned int keyboard;
    JoystickEmulation joystick_emulation;
    unsigned int joysticks;

--- a/src/gui/includes/CapriceOptions.h
+++ b/src/gui/includes/CapriceOptions.h
@@ -70,6 +70,9 @@ namespace wGui
       CLabel* m_pLabelPrinterToFile;     // Capture printer output to file
       CCheckBox* m_pCheckBoxPrinterToFile;
 
+      CLabel* m_pLabelNet4CPC;           // Enable Net4CPC (W5100S) emulation
+      CCheckBox* m_pCheckBoxNet4CPC;
+
       // Expansion ROMs
       std::vector<CButton *> m_pButtonRoms; // contains pointer to 16 'ROM buttons'
 

--- a/src/gui/src/CapriceOptions.cpp
+++ b/src/gui/src/CapriceOptions.cpp
@@ -7,6 +7,7 @@
 #include "std_ex.h"
 #include "CapriceOptions.h"
 #include "cap32.h"
+#include "net4cpc.h"
 #include "keyboard.h"
 #include "fileutils.h"
 #include "wg_messagebox.h"
@@ -98,6 +99,13 @@ CapriceOptions::CapriceOptions(const CRect& WindowRect, CWindow* pParent, CFontE
         m_pCheckBoxPrinterToFile->SetCheckBoxState(CCheckBox::CHECKED);
     }
     m_pCheckBoxPrinterToFile->SetIsFocusable(true);
+
+    m_pCheckBoxNet4CPC = new CCheckBox(CRect(CPoint(10, 104), 10, 10), m_pGroupBoxTabGeneral);
+    m_pLabelNet4CPC    = new CLabel(CPoint(27, 105), m_pGroupBoxTabGeneral, "Enable Net4CPC ethernet emulation");
+    if (CPC.net4cpc == 1) {
+        m_pCheckBoxNet4CPC->SetCheckBoxState(CCheckBox::CHECKED);
+    }
+    m_pCheckBoxNet4CPC->SetIsFocusable(true);
 
     // ---------------- Expansion ROMs ----------------
     std::string romFileName;
@@ -324,6 +332,7 @@ bool CapriceOptions::HandleMessage(CMessage* pMessage)
               CPC.limit_speed = (m_pCheckBoxLimitSpeed->GetCheckBoxState() == CCheckBox::CHECKED)?1:0;
               CPC.speed    = m_pScrollBarCPCSpeed->GetValue();
               CPC.printer  = (m_pCheckBoxPrinterToFile->GetCheckBoxState() == CCheckBox::CHECKED)?1:0;
+              CPC.net4cpc  = (m_pCheckBoxNet4CPC->GetCheckBoxState() == CCheckBox::CHECKED)?1:0;
               // Selected ROM slots ( "..." is empty)
               // Take the text on each 'ROM' button, if it is "...", clear the ROM, else
               // set the ROM filename:
@@ -517,6 +526,11 @@ bool CapriceOptions::ProcessOptionChanges(t_CPC& CPC, bool saveChanges) {
         } else {
             printer_stop();
         }
+    }
+
+    // Reset Net4CPC when toggled (closes any open host sockets):
+    if (CPC.net4cpc != m_oldCPCsettings.net4cpc) {
+        net4cpc_reset();
     }
 
     if (CPC.snd_enabled != m_oldCPCsettings.snd_enabled) {

--- a/src/net4cpc.cpp
+++ b/src/net4cpc.cpp
@@ -19,14 +19,41 @@
 
 #include "net4cpc.h"
 
-#include <arpa/inet.h>
 #include <cerrno>
 #include <cstring>
-#include <fcntl.h>
-#include <netinet/in.h>
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <unistd.h>
+
+// ---------------------------------------------------------------------------
+// Platform socket abstraction
+// ---------------------------------------------------------------------------
+
+#ifdef _WIN32
+#  include <winsock2.h>
+#  include <ws2tcpip.h>
+#  pragma comment(lib, "ws2_32.lib")
+   using sock_t = SOCKET;
+   static const sock_t INVALID_SOCK = INVALID_SOCKET;
+   static inline void close_fd(sock_t fd)      { closesocket(fd); }
+   static inline void set_nonblocking(sock_t fd) {
+       u_long mode = 1;
+       ioctlsocket(fd, FIONBIO, &mode);
+   }
+   static inline bool connect_pending() { return WSAGetLastError() == WSAEWOULDBLOCK; }
+#else
+#  include <arpa/inet.h>
+#  include <fcntl.h>
+#  include <netinet/in.h>
+#  include <sys/select.h>
+#  include <sys/socket.h>
+#  include <unistd.h>
+   using sock_t = int;
+   static const sock_t INVALID_SOCK = -1;
+   static inline void close_fd(sock_t fd)      { close(fd); }
+   static inline void set_nonblocking(sock_t fd) {
+       int flags = fcntl(fd, F_GETFL, 0);
+       fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+   }
+   static inline bool connect_pending() { return errno == EINPROGRESS; }
+#endif
 
 // ---------------------------------------------------------------------------
 // W5100S register-space constants
@@ -74,10 +101,10 @@ static const uint8_t SCMD_RECV    = 0x40;
 // Emulator state
 // ---------------------------------------------------------------------------
 
-static uint8_t  regs[65536];    // W5100S register/buffer space
-static uint16_t idm_ar = 0;     // current indirect address register
-static int      sock_fd[4];     // host socket file descriptors
-static uint16_t rx_wr[4];       // internal RX write pointers (free-running)
+static uint8_t  regs[65536];       // W5100S register/buffer space
+static uint16_t idm_ar = 0;        // current indirect address register
+static sock_t   sock_fd[4];        // host socket file descriptors
+static uint16_t rx_wr[4];          // internal RX write pointers (free-running)
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -104,9 +131,9 @@ static void update_tx_fsr(int s) {
 }
 
 static void close_sock(int s) {
-    if (sock_fd[s] >= 0) {
-        close(sock_fd[s]);
-        sock_fd[s] = -1;
+    if (sock_fd[s] != INVALID_SOCK) {
+        close_fd(sock_fd[s]);
+        sock_fd[s] = INVALID_SOCK;
     }
 }
 
@@ -118,7 +145,7 @@ static void close_sock(int s) {
 // For UDP sockets the W5100S prepends an 8-byte header per datagram:
 //   4 B source IP | 2 B source port | 2 B payload length
 static void poll_rx(int s) {
-    if (sock_fd[s] < 0) return;
+    if (sock_fd[s] == INVALID_SOCK) return;
 
     uint8_t sr = regs[SOCK_BASE[s] + SR_SR];
     if (sr != SSTAT_ESTABLISHED && sr != SSTAT_UDP) return;
@@ -137,9 +164,10 @@ static void poll_rx(int s) {
         uint8_t tmp[2048];
         struct sockaddr_in src{};
         socklen_t srclen = sizeof(src);
-        ssize_t n = recvfrom(sock_fd[s], tmp,
+        ssize_t n = recvfrom(sock_fd[s],
+                             reinterpret_cast<char*>(tmp),
                              payload_space < sizeof(tmp) ? payload_space : sizeof(tmp),
-                             MSG_DONTWAIT,
+                             0,
                              reinterpret_cast<struct sockaddr*>(&src), &srclen);
         if (n <= 0) return;
 
@@ -164,9 +192,10 @@ static void poll_rx(int s) {
 
     } else {
         uint8_t tmp[2048];
-        ssize_t n = recv(sock_fd[s], tmp,
+        ssize_t n = recv(sock_fd[s],
+                         reinterpret_cast<char*>(tmp),
                          space < sizeof(tmp) ? space : sizeof(tmp),
-                         MSG_DONTWAIT);
+                         0);
         if (n < 0) return;
         if (n == 0) {
             regs[SOCK_BASE[s] + SR_SR] = SSTAT_CLOSE_WAIT;
@@ -184,7 +213,7 @@ static void poll_rx(int s) {
 
 // Poll a non-blocking connect() for completion.
 static void poll_connect(int s) {
-    if (sock_fd[s] < 0) return;
+    if (sock_fd[s] == INVALID_SOCK) return;
     if (regs[SOCK_BASE[s] + SR_SR] != SSTAT_SYNSENT) return;
 
     fd_set wfds, efds;
@@ -192,10 +221,11 @@ static void poll_connect(int s) {
     FD_ZERO(&efds); FD_SET(sock_fd[s], &efds);
     struct timeval tv = {0, 0};
 
-    if (select(sock_fd[s] + 1, nullptr, &wfds, &efds, &tv) > 0) {
+    if (select(static_cast<int>(sock_fd[s]) + 1, nullptr, &wfds, &efds, &tv) > 0) {
         int err = 0;
         socklen_t len = sizeof(err);
-        getsockopt(sock_fd[s], SOL_SOCKET, SO_ERROR, &err, &len);
+        getsockopt(sock_fd[s], SOL_SOCKET, SO_ERROR,
+                   reinterpret_cast<char*>(&err), &len);
         if (err == 0) {
             regs[SOCK_BASE[s] + SR_SR] = SSTAT_ESTABLISHED;
             set16(SOCK_BASE[s] + SR_TX_FSR, BUF_SIZE);
@@ -220,9 +250,8 @@ static void handle_command(int s, uint8_t cmd) {
         sock_fd[s] = socket(AF_INET,
                             mode == SMODE_UDP ? SOCK_DGRAM : SOCK_STREAM,
                             0);
-        if (sock_fd[s] >= 0) {
-            int flags = fcntl(sock_fd[s], F_GETFL, 0);
-            fcntl(sock_fd[s], F_SETFL, flags | O_NONBLOCK);
+        if (sock_fd[s] != INVALID_SOCK) {
+            set_nonblocking(sock_fd[s]);
             // Bind to the source IP the CPC configured in SIPR (0x000F–0x0012).
             // If the host has that IP on any interface, traffic will originate
             // from it.  Silently fall back to the host IP if bind fails.
@@ -266,7 +295,7 @@ static void handle_command(int s, uint8_t cmd) {
         int r = connect(sock_fd[s],
                         reinterpret_cast<struct sockaddr*>(&addr),
                         sizeof(addr));
-        if (r == 0 || errno == EINPROGRESS) {
+        if (r == 0 || connect_pending()) {
             regs[SOCK_BASE[s] + SR_SR] = SSTAT_SYNSENT;
         } else {
             regs[SOCK_BASE[s] + SR_SR] = SSTAT_CLOSED;
@@ -280,7 +309,7 @@ static void handle_command(int s, uint8_t cmd) {
         uint16_t tx_wr = get16(SOCK_BASE[s] + SR_TX_WR);
         uint16_t len   = static_cast<uint16_t>(tx_wr - tx_rd);
 
-        if (len > 0 && sock_fd[s] >= 0) {
+        if (len > 0 && sock_fd[s] != INVALID_SOCK) {
             uint8_t buf[2048];
             for (uint16_t i = 0; i < len; i++)
                 buf[i] = regs[TX_BASE[s] + ((tx_rd + i) & BUF_MASK)];
@@ -300,10 +329,10 @@ static void handle_command(int s, uint8_t cmd) {
                     (static_cast<uint32_t>(ip1) << 16) |
                     (static_cast<uint32_t>(ip2) <<  8) |
                      static_cast<uint32_t>(ip3));
-                sendto(sock_fd[s], buf, len, 0,
+                sendto(sock_fd[s], reinterpret_cast<const char*>(buf), len, 0,
                        reinterpret_cast<struct sockaddr*>(&dst), sizeof(dst));
             } else {
-                send(sock_fd[s], buf, len, 0);
+                send(sock_fd[s], reinterpret_cast<const char*>(buf), len, 0);
             }
         }
 
@@ -368,6 +397,14 @@ static void reg_write(uint16_t addr, uint8_t val) {
 // ---------------------------------------------------------------------------
 
 void net4cpc_reset() {
+#ifdef _WIN32
+    static bool wsa_init = false;
+    if (!wsa_init) {
+        WSADATA wsa;
+        WSAStartup(MAKEWORD(2, 2), &wsa);
+        wsa_init = true;
+    }
+#endif
     memset(regs, 0, sizeof(regs));
     idm_ar = 0;
     for (int s = 0; s < 4; s++) {

--- a/src/net4cpc.cpp
+++ b/src/net4cpc.cpp
@@ -1,0 +1,416 @@
+/* net4cpc.cpp - W5100S / Net4CPC hardware emulation for Caprice32
+ *
+ * Emulates the W5100S Ethernet controller as accessed through the Net4CPC
+ * expansion board at I/O ports 0xFD20–0xFD23 (indirect parallel bus mode).
+ *
+ * Register space layout (same as real W5100S):
+ *   0x0000–0x002F  Common registers (MR, GAR, SUBR, SHAR, SIPR, RTR, …)
+ *   0x0400–0x04FF  Socket 0 registers
+ *   0x0500–0x05FF  Socket 1 registers
+ *   0x0600–0x06FF  Socket 2 registers
+ *   0x0700–0x07FF  Socket 3 registers
+ *   0x4000–0x5FFF  TX ring buffers (2 KB × 4 sockets)
+ *   0x6000–0x7FFF  RX ring buffers (2 KB × 4 sockets)
+ *
+ * UDP sockets: the W5100S prepends an 8-byte header to each received
+ * datagram in the RX buffer: 4 bytes source IP, 2 bytes source port,
+ * 2 bytes payload length.  This emulation replicates that behaviour.
+ */
+
+#include "net4cpc.h"
+
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+// ---------------------------------------------------------------------------
+// W5100S register-space constants
+// ---------------------------------------------------------------------------
+
+static const uint16_t SOCK_BASE[4] = { 0x0400, 0x0500, 0x0600, 0x0700 };
+static const uint16_t TX_BASE[4]   = { 0x4000, 0x4800, 0x5000, 0x5800 };
+static const uint16_t RX_BASE[4]   = { 0x6000, 0x6800, 0x7000, 0x7800 };
+static const uint16_t BUF_MASK     = 0x07FFu; // 2 KB per socket
+static const uint16_t BUF_SIZE     = 2048u;
+
+// Socket register offsets from SOCK_BASE[n]
+static const uint16_t SR_MR    = 0x00;
+static const uint16_t SR_CR    = 0x01;
+static const uint16_t SR_SR    = 0x03;
+static const uint16_t SR_DIPR  = 0x0C; // 4 bytes, big-endian
+static const uint16_t SR_DPORT = 0x10; // 2 bytes, big-endian
+static const uint16_t SR_TX_FSR = 0x20; // 2 bytes
+static const uint16_t SR_TX_RD  = 0x22; // 2 bytes (chip's read pointer)
+static const uint16_t SR_TX_WR  = 0x24; // 2 bytes (CPC's write pointer)
+static const uint16_t SR_RX_RSR = 0x26; // 2 bytes
+static const uint16_t SR_RX_RD  = 0x28; // 2 bytes (CPC's read pointer)
+
+// Socket modes
+static const uint8_t SMODE_TCP = 0x01;
+static const uint8_t SMODE_UDP = 0x02;
+
+// Socket status values
+static const uint8_t SSTAT_CLOSED      = 0x00;
+static const uint8_t SSTAT_INIT        = 0x13;
+static const uint8_t SSTAT_SYNSENT     = 0x15;
+static const uint8_t SSTAT_ESTABLISHED = 0x17;
+static const uint8_t SSTAT_CLOSE_WAIT  = 0x1C;
+static const uint8_t SSTAT_UDP         = 0x22;
+
+// Socket commands
+static const uint8_t SCMD_OPEN    = 0x01;
+static const uint8_t SCMD_CONNECT = 0x04;
+static const uint8_t SCMD_DISCON  = 0x08;
+static const uint8_t SCMD_CLOSE   = 0x10;
+static const uint8_t SCMD_SEND    = 0x20;
+static const uint8_t SCMD_RECV    = 0x40;
+
+// ---------------------------------------------------------------------------
+// Emulator state
+// ---------------------------------------------------------------------------
+
+static uint8_t  regs[65536];    // W5100S register/buffer space
+static uint16_t idm_ar = 0;     // current indirect address register
+static int      sock_fd[4];     // host socket file descriptors
+static uint16_t rx_wr[4];       // internal RX write pointers (free-running)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static void set16(uint16_t addr, uint16_t val) {
+    regs[addr]   = static_cast<uint8_t>(val >> 8);
+    regs[addr+1] = static_cast<uint8_t>(val & 0xFF);
+}
+
+static uint16_t get16(uint16_t addr) {
+    return (static_cast<uint16_t>(regs[addr]) << 8) | regs[addr+1];
+}
+
+static void update_rx_rsr(int s) {
+    uint16_t rsr = static_cast<uint16_t>(rx_wr[s] - get16(SOCK_BASE[s] + SR_RX_RD));
+    set16(SOCK_BASE[s] + SR_RX_RSR, rsr);
+}
+
+static void update_tx_fsr(int s) {
+    uint16_t used = static_cast<uint16_t>(
+        get16(SOCK_BASE[s] + SR_TX_WR) - get16(SOCK_BASE[s] + SR_TX_RD));
+    set16(SOCK_BASE[s] + SR_TX_FSR, BUF_SIZE - used);
+}
+
+static void close_sock(int s) {
+    if (sock_fd[s] >= 0) {
+        close(sock_fd[s]);
+        sock_fd[s] = -1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Receive polling
+// ---------------------------------------------------------------------------
+
+// Pull any available data from the host socket into the W5100S RX ring buffer.
+// For UDP sockets the W5100S prepends an 8-byte header per datagram:
+//   4 B source IP | 2 B source port | 2 B payload length
+static void poll_rx(int s) {
+    if (sock_fd[s] < 0) return;
+
+    uint8_t sr = regs[SOCK_BASE[s] + SR_SR];
+    if (sr != SSTAT_ESTABLISHED && sr != SSTAT_UDP) return;
+
+    uint16_t used  = static_cast<uint16_t>(rx_wr[s] - get16(SOCK_BASE[s] + SR_RX_RD));
+    uint16_t space = BUF_SIZE - used;
+    if (space == 0) return;
+
+    uint8_t mode = regs[SOCK_BASE[s] + SR_MR] & 0x0F;
+
+    if (mode == SMODE_UDP) {
+        // Leave room for the 8-byte header we will prepend
+        if (space <= 8) return;
+        uint16_t payload_space = space - 8;
+
+        uint8_t tmp[2048];
+        struct sockaddr_in src{};
+        socklen_t srclen = sizeof(src);
+        ssize_t n = recvfrom(sock_fd[s], tmp,
+                             payload_space < sizeof(tmp) ? payload_space : sizeof(tmp),
+                             MSG_DONTWAIT,
+                             reinterpret_cast<struct sockaddr*>(&src), &srclen);
+        if (n <= 0) return;
+
+        // Write 8-byte W5100S UDP header
+        uint32_t src_ip = ntohl(src.sin_addr.s_addr);
+        uint16_t src_port = ntohs(src.sin_port);
+
+        auto write_rx = [&](uint8_t b) {
+            regs[RX_BASE[s] + (rx_wr[s] & BUF_MASK)] = b;
+            rx_wr[s]++;
+        };
+        write_rx(static_cast<uint8_t>(src_ip >> 24));
+        write_rx(static_cast<uint8_t>(src_ip >> 16));
+        write_rx(static_cast<uint8_t>(src_ip >> 8));
+        write_rx(static_cast<uint8_t>(src_ip));
+        write_rx(static_cast<uint8_t>(src_port >> 8));
+        write_rx(static_cast<uint8_t>(src_port));
+        write_rx(static_cast<uint8_t>(n >> 8));
+        write_rx(static_cast<uint8_t>(n));
+
+        for (ssize_t i = 0; i < n; i++) write_rx(tmp[i]);
+
+    } else {
+        uint8_t tmp[2048];
+        ssize_t n = recv(sock_fd[s], tmp,
+                         space < sizeof(tmp) ? space : sizeof(tmp),
+                         MSG_DONTWAIT);
+        if (n < 0) return;
+        if (n == 0) {
+            regs[SOCK_BASE[s] + SR_SR] = SSTAT_CLOSE_WAIT;
+            close_sock(s);
+            return;
+        }
+        for (ssize_t i = 0; i < n; i++) {
+            regs[RX_BASE[s] + (rx_wr[s] & BUF_MASK)] = tmp[i];
+            rx_wr[s]++;
+        }
+    }
+
+    update_rx_rsr(s);
+}
+
+// Poll a non-blocking connect() for completion.
+static void poll_connect(int s) {
+    if (sock_fd[s] < 0) return;
+    if (regs[SOCK_BASE[s] + SR_SR] != SSTAT_SYNSENT) return;
+
+    fd_set wfds, efds;
+    FD_ZERO(&wfds); FD_SET(sock_fd[s], &wfds);
+    FD_ZERO(&efds); FD_SET(sock_fd[s], &efds);
+    struct timeval tv = {0, 0};
+
+    if (select(sock_fd[s] + 1, nullptr, &wfds, &efds, &tv) > 0) {
+        int err = 0;
+        socklen_t len = sizeof(err);
+        getsockopt(sock_fd[s], SOL_SOCKET, SO_ERROR, &err, &len);
+        if (err == 0) {
+            regs[SOCK_BASE[s] + SR_SR] = SSTAT_ESTABLISHED;
+            set16(SOCK_BASE[s] + SR_TX_FSR, BUF_SIZE);
+        } else {
+            regs[SOCK_BASE[s] + SR_SR] = SSTAT_CLOSED;
+            close_sock(s);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Socket command dispatch
+// ---------------------------------------------------------------------------
+
+static void handle_command(int s, uint8_t cmd) {
+    uint8_t mode = regs[SOCK_BASE[s] + SR_MR] & 0x0F;
+
+    switch (cmd) {
+
+    case SCMD_OPEN:
+        close_sock(s);
+        sock_fd[s] = socket(AF_INET,
+                            mode == SMODE_UDP ? SOCK_DGRAM : SOCK_STREAM,
+                            0);
+        if (sock_fd[s] >= 0) {
+            int flags = fcntl(sock_fd[s], F_GETFL, 0);
+            fcntl(sock_fd[s], F_SETFL, flags | O_NONBLOCK);
+            // Bind to the source IP the CPC configured in SIPR (0x000F–0x0012).
+            // If the host has that IP on any interface, traffic will originate
+            // from it.  Silently fall back to the host IP if bind fails.
+            uint32_t sipr = (static_cast<uint32_t>(regs[0x000F]) << 24) |
+                            (static_cast<uint32_t>(regs[0x0010]) << 16) |
+                            (static_cast<uint32_t>(regs[0x0011]) <<  8) |
+                             static_cast<uint32_t>(regs[0x0012]);
+            if (sipr != 0) {
+                struct sockaddr_in src{};
+                src.sin_family      = AF_INET;
+                src.sin_port        = 0;
+                src.sin_addr.s_addr = htonl(sipr);
+                bind(sock_fd[s], reinterpret_cast<struct sockaddr*>(&src), sizeof(src));
+            }
+            regs[SOCK_BASE[s] + SR_SR] = (mode == SMODE_TCP) ? SSTAT_INIT : SSTAT_UDP;
+            set16(SOCK_BASE[s] + SR_TX_FSR, BUF_SIZE);
+            set16(SOCK_BASE[s] + SR_TX_WR, 0);
+            set16(SOCK_BASE[s] + SR_TX_RD, 0);
+            set16(SOCK_BASE[s] + SR_RX_RSR, 0);
+            set16(SOCK_BASE[s] + SR_RX_RD, 0);
+            rx_wr[s] = 0;
+        }
+        break;
+
+    case SCMD_CONNECT: {
+        uint8_t  ip0   = regs[SOCK_BASE[s] + SR_DIPR];
+        uint8_t  ip1   = regs[SOCK_BASE[s] + SR_DIPR + 1];
+        uint8_t  ip2   = regs[SOCK_BASE[s] + SR_DIPR + 2];
+        uint8_t  ip3   = regs[SOCK_BASE[s] + SR_DIPR + 3];
+        uint16_t dport = get16(SOCK_BASE[s] + SR_DPORT);
+
+        struct sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port   = htons(dport);
+        addr.sin_addr.s_addr = htonl(
+            (static_cast<uint32_t>(ip0) << 24) |
+            (static_cast<uint32_t>(ip1) << 16) |
+            (static_cast<uint32_t>(ip2) <<  8) |
+             static_cast<uint32_t>(ip3));
+
+        int r = connect(sock_fd[s],
+                        reinterpret_cast<struct sockaddr*>(&addr),
+                        sizeof(addr));
+        if (r == 0 || errno == EINPROGRESS) {
+            regs[SOCK_BASE[s] + SR_SR] = SSTAT_SYNSENT;
+        } else {
+            regs[SOCK_BASE[s] + SR_SR] = SSTAT_CLOSED;
+            close_sock(s);
+        }
+        break;
+    }
+
+    case SCMD_SEND: {
+        uint16_t tx_rd = get16(SOCK_BASE[s] + SR_TX_RD);
+        uint16_t tx_wr = get16(SOCK_BASE[s] + SR_TX_WR);
+        uint16_t len   = static_cast<uint16_t>(tx_wr - tx_rd);
+
+        if (len > 0 && sock_fd[s] >= 0) {
+            uint8_t buf[2048];
+            for (uint16_t i = 0; i < len; i++)
+                buf[i] = regs[TX_BASE[s] + ((tx_rd + i) & BUF_MASK)];
+
+            if (mode == SMODE_UDP) {
+                uint8_t  ip0   = regs[SOCK_BASE[s] + SR_DIPR];
+                uint8_t  ip1   = regs[SOCK_BASE[s] + SR_DIPR + 1];
+                uint8_t  ip2   = regs[SOCK_BASE[s] + SR_DIPR + 2];
+                uint8_t  ip3   = regs[SOCK_BASE[s] + SR_DIPR + 3];
+                uint16_t dport = get16(SOCK_BASE[s] + SR_DPORT);
+
+                struct sockaddr_in dst{};
+                dst.sin_family = AF_INET;
+                dst.sin_port   = htons(dport);
+                dst.sin_addr.s_addr = htonl(
+                    (static_cast<uint32_t>(ip0) << 24) |
+                    (static_cast<uint32_t>(ip1) << 16) |
+                    (static_cast<uint32_t>(ip2) <<  8) |
+                     static_cast<uint32_t>(ip3));
+                sendto(sock_fd[s], buf, len, 0,
+                       reinterpret_cast<struct sockaddr*>(&dst), sizeof(dst));
+            } else {
+                send(sock_fd[s], buf, len, 0);
+            }
+        }
+
+        set16(SOCK_BASE[s] + SR_TX_RD, tx_wr);
+        update_tx_fsr(s);
+        break;
+    }
+
+    case SCMD_RECV:
+        update_rx_rsr(s);
+        poll_rx(s);
+        break;
+
+    case SCMD_DISCON:
+    case SCMD_CLOSE:
+        close_sock(s);
+        regs[SOCK_BASE[s] + SR_SR] = SSTAT_CLOSED;
+        set16(SOCK_BASE[s] + SR_RX_RSR, 0);
+        set16(SOCK_BASE[s] + SR_TX_FSR, 0);
+        rx_wr[s] = 0;
+        break;
+
+    default:
+        break;
+    }
+
+    regs[SOCK_BASE[s] + SR_CR] = 0x00; // command register self-clears
+}
+
+// ---------------------------------------------------------------------------
+// Register read/write with side-effects
+// ---------------------------------------------------------------------------
+
+static uint8_t reg_read(uint16_t addr) {
+    for (int s = 0; s < 4; s++) {
+        if (addr == SOCK_BASE[s] + SR_SR) {
+            poll_connect(s);
+            return regs[addr];
+        }
+        // Reading either byte of RX_RSR triggers a receive poll
+        if (addr == SOCK_BASE[s] + SR_RX_RSR ||
+            addr == SOCK_BASE[s] + SR_RX_RSR + 1) {
+            poll_rx(s);
+            return regs[addr];
+        }
+    }
+    return regs[addr];
+}
+
+static void reg_write(uint16_t addr, uint8_t val) {
+    regs[addr] = val;
+    for (int s = 0; s < 4; s++) {
+        if (addr == SOCK_BASE[s] + SR_CR && val != 0) {
+            handle_command(s, val);
+            return;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void net4cpc_reset() {
+    memset(regs, 0, sizeof(regs));
+    idm_ar = 0;
+    for (int s = 0; s < 4; s++) {
+        close_sock(s);
+        rx_wr[s] = 0;
+    }
+    // MR = 0x03: auto-increment enabled, indirect bus mode active.
+    // The n4c-nettools code reads this port to confirm the chip is present.
+    regs[0x0000] = 0x03;
+}
+
+byte net4cpc_in(byte reg_sel) {
+    switch (reg_sel & 0x03) {
+    case 0: // MR – direct shortcut to register 0x0000
+        return regs[0x0000];
+    case 1: // IDM_ARH
+        return static_cast<byte>(idm_ar >> 8);
+    case 2: // IDM_ARL
+        return static_cast<byte>(idm_ar & 0xFF);
+    case 3: { // IDM_DR
+        byte val = reg_read(idm_ar);
+        if (regs[0x0000] & 0x02) idm_ar++; // auto-increment when AI bit set
+        return val;
+    }
+    default:
+        return 0xFF;
+    }
+}
+
+void net4cpc_out(byte reg_sel, byte val) {
+    switch (reg_sel & 0x03) {
+    case 0: // MR
+        regs[0x0000] = val;
+        break;
+    case 1: // IDM_ARH
+        idm_ar = static_cast<uint16_t>((idm_ar & 0x00FFu) | (static_cast<uint16_t>(val) << 8));
+        break;
+    case 2: // IDM_ARL
+        idm_ar = static_cast<uint16_t>((idm_ar & 0xFF00u) | val);
+        break;
+    case 3: // IDM_DR
+        reg_write(idm_ar, val);
+        if (regs[0x0000] & 0x02) idm_ar++; // auto-increment when AI bit set
+        break;
+    }
+}

--- a/src/net4cpc.cpp
+++ b/src/net4cpc.cpp
@@ -3,7 +3,10 @@
  * Emulates the W5100S Ethernet controller as accessed through the Net4CPC
  * expansion board at I/O ports 0xFD20–0xFD23 (indirect parallel bus mode).
  *
- * Register space layout (same as real W5100S):
+ * The W5100S supports up to 4 independent, simultaneous hardware sockets
+ * (Sockets 0–3) capable of TCP and UDP.
+ *
+ * Memory layout (same as real W5100S):
  *   0x0000–0x002F  Common registers (MR, GAR, SUBR, SHAR, SIPR, RTR, …)
  *   0x0400–0x04FF  Socket 0 registers
  *   0x0500–0x05FF  Socket 1 registers

--- a/src/net4cpc.h
+++ b/src/net4cpc.h
@@ -1,0 +1,18 @@
+/* net4cpc.h - W5100S / Net4CPC hardware emulation for Caprice32
+ *
+ * The Net4CPC add-on board exposes four Z80 I/O ports:
+ *   0xFD20  MR      – Mode Register (reads 0x03 when chip present)
+ *   0xFD21  IDM_ARH – high byte of 16-bit indirect address
+ *   0xFD22  IDM_ARL – low byte  of 16-bit indirect address
+ *   0xFD23  IDM_DR  – data read/write; address auto-increments after each
+ *                     access when MR bit 1 (AI) is set
+ *
+ * Socket operations are mapped to host POSIX sockets.
+ */
+
+#pragma once
+#include "types.h"
+
+void net4cpc_reset();
+byte net4cpc_in(byte reg_sel);   // reg_sel = port_low & 0x03
+void net4cpc_out(byte reg_sel, byte val);


### PR DESCRIPTION
As per our conversation. This is a draft of support of W5100s-based devices such as the Net4CPC. I have tested this only on Linux using the tools in this disk image https://github.com/salvogendut/cpc-sdcc/tree/master/images/n4c_tools.dsk . In this disk there is a tool called N4CCFG.BAS , you run it and set your static IP address, Gateway, Netmask and DNS Server, then it will write a config file called N4C.CFG. The tools in the disk will use that to retrieve the network configuration. I have tried the telnet.bas and the ntp.bas and they should work.  Alternatively you could try it with SymbOS net-n4c.exe network daemon.