### PR TITLE
Benchmarking Z80 code

### DIFF
--- a/doc/man.html
+++ b/doc/man.html
@@ -1,5 +1,5 @@
-<!-- Creator     : groff version 1.22.4 -->
-<!-- CreationDate: Sat Oct  7 02:26:21 2023 -->
+<!-- Creator     : groff version 1.23.0 -->
+<!-- CreationDate: Sun Jun 14 12:40:47 2026 -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -38,7 +38,7 @@
 </h2>
 
 
-<p style="margin-left:11%; margin-top: 1em">cap32 -
+<p style="margin-left:9%; margin-top: 1em">cap32 -
 Caprice32 Amstrad CPC emulator</p>
 
 <h2>SYNOPSIS
@@ -46,7 +46,7 @@ Caprice32 Amstrad CPC emulator</p>
 </h2>
 
 
-<p style="margin-left:11%; margin-top: 1em"><b>cap32</b>
+<p style="margin-left:9%; margin-top: 1em"><b>cap32</b>
 [<i>OPTION</i>]... [<i>FILE</i>]...</p>
 
 <h2>DESCRIPTION
@@ -55,14 +55,14 @@ Caprice32 Amstrad CPC emulator</p>
 
 
 
-<p style="margin-left:11%; margin-top: 1em"><b>Caprice32</b>
+<p style="margin-left:9%; margin-top: 1em"><b>Caprice32</b>
 is an Amstrad CPC emulator. It emulates the Amstrad CPC464,
 664, 6128 and 6128+ home computers.</p>
 
-<p style="margin-left:11%; margin-top: 1em"><b>Media
+<p style="margin-left:9%; margin-top: 1em"><b>Media
 loading</b></p>
 
-<p style="margin-left:22%;">Upon invocation, the FILEs
+<p style="margin-left:18%;">Upon invocation, the FILEs
 specified as arguments will be used to populate the various
 available CPC machine slots. The type of slot is determined
 by the file format, detected by its extension. Caprice32
@@ -71,15 +71,15 @@ image), <b>.ipf</b> (Interchangeable Preservation Format
 disk image), <b>.raw</b> (CT-RAW format), <b>.voc</b> or
 <b>.cdt</b> (tape image), <b>.cpr</b> (cartridge image),
 <b>.sna</b> (snapshot image), <b>.zip</b> (zip of any
-previously described file). Specifying slot content on
-the command line is optional.</p>
+previously described file). Specifying slot content on the
+command line is optional.</p>
 
-<p style="margin-left:22%; margin-top: 1em">Caprice32
+<p style="margin-left:18%; margin-top: 1em">Caprice32
 supports two disk drives: drive A and drive B. If two disk
 image files (.dsk or .ipf) are provided, the first one will
 be loaded in drive A and the second one in drive B.</p>
 
-<p style="margin-left:22%; margin-top: 1em">The
+<p style="margin-left:18%; margin-top: 1em">The
 <b>cart_path</b>, <b>snap_path</b>, <b>dsk_path</b> and
 <b>tape_path</b> entries in the configuration file are
 <i>only</i> used to specify the directory to open when
@@ -87,15 +87,15 @@ loading/saving files in the GUI. The full path to the
 various slot contents must be provided on the command
 line.</p>
 
-<p style="margin-left:22%; margin-top: 1em">The
+<p style="margin-left:18%; margin-top: 1em">The
 <b>rom_path</b> entry in the configuration file is used by
 the emulator to find its <i>system</i> ROM and
 cartridges.</p>
 
 
-<p style="margin-left:11%; margin-top: 1em"><b>Configuration</b></p>
+<p style="margin-left:9%; margin-top: 1em"><b>Configuration</b></p>
 
-<p style="margin-left:22%;">When launched, Caprice32 will
+<p style="margin-left:18%;">When launched, Caprice32 will
 look for a configuration file in several locations. If a
 configuration file was specified using the <b>--cfg_file</b>
 command line switch, Caprice32 will try and use it. If no
@@ -114,7 +114,7 @@ Caprice32 will use the first valid file it finds. If no
 configuration file is found, a default configuration will be
 used.</p>
 
-<p style="margin-left:22%; margin-top: 1em">The
+<p style="margin-left:18%; margin-top: 1em">The
 configuration file contains various configuration
 parameters, some of which can be modified from the GUI. When
 saving the configuration from the GUI, it will be written in
@@ -122,16 +122,16 @@ the configuration file following the same order than
 previously described, except for the addition of the write
 permission condition.</p>
 
-<p style="margin-left:22%; margin-top: 1em">Most of the
+<p style="margin-left:18%; margin-top: 1em">Most of the
 configuration file entries are commented in the
 configuration file provided by default with Caprice32.
 However, when overwriting the configuration file from the
 emulator menu, all comments will be lost.</p>
 
 
-<p style="margin-left:11%; margin-top: 1em"><b>Control</b></p>
+<p style="margin-left:9%; margin-top: 1em"><b>Control</b></p>
 
-<p style="margin-left:22%;">Emulator functionalities are
+<p style="margin-left:18%;">Emulator functionalities are
 available through function keys (F1-F12). As CPC also had
 function keys, those are emulated by keys from the numpad.
 This makes sense since their disposition on the CPC keyboard
@@ -142,10 +142,10 @@ through the virtual keyboard. The emulator function key
 mapping can also be redefined through the host keyboard
 mapping file.</p>
 
-<p style="margin-left:22%; margin-top: 1em">The emulator
+<p style="margin-left:18%; margin-top: 1em">The emulator
 function default key mapping is:</p>
 
-<p style="margin-left:32%;"><b>F1</b> - Show GUI (and pause
+<p style="margin-left:27%;"><b>F1</b> - Show GUI (and pause
 the emulator) <b><br>
 F2</b> - Toggle fullscreen / windowed mode <b><br>
 F3</b> - Take screenshot <b><br>
@@ -160,26 +160,26 @@ F12</b> - Toggle debug mode <b><br>
 Shift+F1</b> - Show virtual keyboard <b><br>
 Shift+F3</b> - Take a machine snapshot</p>
 
-<p style="margin-left:11%; margin-top: 1em"><b>Joystick
+<p style="margin-left:9%; margin-top: 1em"><b>Joystick
 support</b></p>
 
-<p style="margin-left:22%;">Joystick emulation can be
+<p style="margin-left:18%;">Joystick emulation can be
 turned on with the F7 key. When joystick emulation is on,
 real joysticks are disabled, and the keyboard arrows
 (directions) as well as X and Z (fire buttons) keys are
 remapped to emulate the joystick 1 of the CPC machine.</p>
 
-<p style="margin-left:22%; margin-top: 1em">Caprice32 can
+<p style="margin-left:18%; margin-top: 1em">Caprice32 can
 also be controlled completely from the joystick. The
 configuration file <b>joystick_menu_button</b> and
 <b>joystick_vkeyboard_button</b> entries allow binding menu
 and virtual keyboard invocations to some of the (host)
 joystick button.</p>
 
-<p style="margin-left:11%; margin-top: 1em"><b>Keyboard
+<p style="margin-left:9%; margin-top: 1em"><b>Keyboard
 mapping</b></p>
 
-<p style="margin-left:22%;">Caprice32 supports CPC English,
+<p style="margin-left:18%;">Caprice32 supports CPC English,
 French and Spanish keyboard layouts. The CPC keyboard layout
 is defined in the configuration file by the <b>keyboard</b>
 entry (0: English, 1: French, 2: Spanish). The host keyboard
@@ -191,62 +191,106 @@ configuration file <b>resources_path</b> entry. If the
 mapping file is not defined or not found, Caprice32 will
 default to a standard US keyboard map.</p>
 
+
+<p style="margin-left:9%; margin-top: 1em"><b>Benchmarking</b></p>
+
+<p style="margin-left:18%;">When started with
+<b>--benchmark</b>, Caprice32 measures Z80 T-states (wait
+states included, as on real hardware) and is driven by the
+emulated program through OUT instructions to three
+otherwise-inert I/O ports. The command is selected by the
+port; the written value is ignored: <br>
+- <b>&amp;FED0</b> (START): capture the baseline T-state
+count. <br>
+- <b>&amp;FED1</b> (STOP): print the elapsed T-states
+(current minus baseline) as a single integer to stdout and
+quit the emulator. <br>
+- <b>&amp;FED2</b> (LAP): print a partial result to stderr
+and keep running.</p>
+
+<p style="margin-left:18%; margin-top: 1em">A
+human-readable summary (microseconds and frame count) is
+written to stderr, so stdout carries only the integer and
+can be captured directly, e.g. <b>C=$(cap32 --benchmark
+engine.sna)</b>. If STOP is reached without a prior START,
+the count is measured from boot.</p>
+
+<p style="margin-left:18%; margin-top: 1em">The measured
+delta includes a small, constant marker overhead, so compare
+versions instrumented with the same markers. Each LAP
+between START and STOP adds its own cycles to the final
+total. To exclude the 50 Hz interrupt from the count, wrap
+the measured region in <b>DI</b> ... <b>EI</b>. These ports
+are inert on real CPC hardware (the Multiface 2 only answers
+&amp;FEE8/&amp;FEEA, and only when fitted), so an
+instrumented snapshot still runs harmlessly elsewhere.
+Ready-to-use assembler macros and BASIC examples are
+provided in <b>doc/z80_bench.md</b>.</p>
+
 <h2>OPTIONS
 <a name="OPTIONS"></a>
 </h2>
 
 
-<p style="margin-left:11%; margin-top: 1em"><b>-a</b>,
+<p style="margin-left:9%; margin-top: 1em"><b>-a</b>,
 <b>--autocmd</b>=<i>COMMAND</i></p>
 
-<p style="margin-left:22%;">pass command to execute to the
+<p style="margin-left:18%;">pass command to execute to the
 emulator. The option can be repeated to pass multiple
 commands. For example: cap32 -a &rsquo;print
 &quot;Hello&quot;&rsquo; -a &rsquo;print
 &quot;World&quot;&rsquo;</p>
 
-<p style="margin-left:11%;"><b>-c</b>,
+<p style="margin-left:9%;"><b>-b</b>,
+<b>--benchmark</b></p>
+
+<p style="margin-left:18%;">measure the number of Z80
+T-states executed between the START and STOP markers, print
+that count as a single integer to stdout and exit. Runs
+headless at full speed. See the <b>Benchmarking</b>
+section.</p>
+
+<p style="margin-left:9%;"><b>-c</b>,
 <b>--cfg_file</b>=<i>FILE</i></p>
 
-<p style="margin-left:22%;">use FILE as the emulator
+<p style="margin-left:18%;">use FILE as the emulator
 configuration file.</p>
 
-<p style="margin-left:11%;"><b>-h</b>, <b>--help</b></p>
+<p style="margin-left:9%;"><b>-h</b>, <b>--help</b></p>
 
-<p style="margin-left:22%;">display short help and
+<p style="margin-left:18%;">display short help and
 exits</p>
 
-<p style="margin-left:11%;"><b>-i</b>, <b>--inject</b></p>
+<p style="margin-left:9%;"><b>-i</b>, <b>--inject</b></p>
 
-<p style="margin-left:22%;">inject a binary in memory after
+<p style="margin-left:18%;">inject a binary in memory after
 the CPC startup finishes</p>
 
-<p style="margin-left:11%;"><b>-o</b>, <b>--offset</b></p>
+<p style="margin-left:9%;"><b>-o</b>, <b>--offset</b></p>
 
-<p style="margin-left:22%;">offset at which to inject the
+<p style="margin-left:18%;">offset at which to inject the
 binary provided with -i (default: 0x6000)</p>
 
-<p style="margin-left:11%;"><b>-O</b>,
-<b>--override</b></p>
+<p style="margin-left:9%;"><b>-O</b>, <b>--override</b></p>
 
-<p style="margin-left:22%;">override an option from the
+<p style="margin-left:18%;">override an option from the
 config. Can be repeated. (example: -O system.model=3)</p>
 
-<p style="margin-left:11%;"><b>-s</b>,
+<p style="margin-left:9%;"><b>-s</b>,
 <b>--sym_file</b>=<i>file</i></p>
 
-<p style="margin-left:22%;">use &lt;file&gt; as a source of
+<p style="margin-left:18%;">use &lt;file&gt; as a source of
 symbols and entry points for disassembling in
 developers&rsquo; tools.</p>
 
-<p style="margin-left:11%;"><b>-V</b>, <b>--version</b></p>
+<p style="margin-left:9%;"><b>-V</b>, <b>--version</b></p>
 
-<p style="margin-left:22%;">display Caprice32 version and
+<p style="margin-left:18%;">display Caprice32 version and
 exits</p>
 
-<p style="margin-left:11%;"><b>-v</b>, <b>--verbose</b></p>
+<p style="margin-left:9%;"><b>-v</b>, <b>--verbose</b></p>
 
-<p style="margin-left:22%;">be talkative about what the
+<p style="margin-left:18%;">be talkative about what the
 emulator is doing (mostly for debug builds)</p>
 
 <h2>EXAMPLES
@@ -254,23 +298,31 @@ emulator is doing (mostly for debug builds)</p>
 </h2>
 
 
-<p style="margin-left:11%; margin-top: 1em">cap32
+<p style="margin-left:9%; margin-top: 1em">cap32
 ./disk/sorcery.dsk ./trail.dsk</p>
 
-<p style="margin-left:22%;">Launches cap32, loads the
+<p style="margin-left:18%;">Launches cap32, loads the
 content of ./disk/sorcery.dsk in the drive A slot, and
 ./trail.dsk in the drive B slot.</p>
+
+<p style="margin-left:9%; margin-top: 1em">cap32
+--benchmark ./engine.sna</p>
+
+<p style="margin-left:18%;">Runs engine.sna headless and
+prints to stdout the number of Z80 T-states executed between
+its START (OUT &amp;FED0) and STOP (OUT &amp;FED1)
+markers.</p>
 
 <h2>BUGS
 <a name="BUGS"></a>
 </h2>
 
 
-<p style="margin-left:11%; margin-top: 1em">CPC6128+
+<p style="margin-left:9%; margin-top: 1em">CPC6128+
 emulation is incomplete: vectored &amp; DMA interrupts,
 analog joysticks and 8 bit printer are not emulated.</p>
 
-<p style="margin-left:11%; margin-top: 1em">See
+<p style="margin-left:9%; margin-top: 1em">See
 https://github.com/ColinPitrat/caprice32/issues for the list
 of reported bugs.</p>
 
@@ -279,13 +331,13 @@ of reported bugs.</p>
 </h2>
 
 
-<p style="margin-left:11%; margin-top: 1em">Caprice32 was
+<p style="margin-left:9%; margin-top: 1em">Caprice32 was
 originally written by Ulrich Doewich.</p>
 
-<p style="margin-left:11%; margin-top: 1em">This manual
-page covers Colin Pitrat&rsquo;s fork of Caprice32.</p>
+<p style="margin-left:9%; margin-top: 1em">This manual page
+covers Colin Pitrat&rsquo;s fork of Caprice32.</p>
 
-<p style="margin-left:11%; margin-top: 1em">The screen
+<p style="margin-left:9%; margin-top: 1em">The screen
 capture code uses driedfruit SDL_SavePNG code
 (https://github.com/driedfruit/SDL_SavePNG).</p>
 
@@ -295,7 +347,7 @@ capture code uses driedfruit SDL_SavePNG code
 
 
 
-<p style="margin-left:11%; margin-top: 1em">$HOME/.cap32.cfg
+<p style="margin-left:9%; margin-top: 1em">$HOME/.cap32.cfg
 <br>
 /etc/cap32.cfg</p>
 
@@ -305,7 +357,7 @@ capture code uses driedfruit SDL_SavePNG code
 
 
 
-<p style="margin-left:11%; margin-top: 1em">https://github.com/ColinPitrat/caprice32
+<p style="margin-left:9%; margin-top: 1em">https://github.com/ColinPitrat/caprice32
 <br>
  https://github.com/driedfruit/SDL_SavePNG</p>
 <hr>

--- a/doc/man6/cap32.6
+++ b/doc/man6/cap32.6
@@ -103,6 +103,22 @@ The mapping file must be put in the resources directory, defined by the configur
 If the mapping file is not defined or not found, Caprice32 will default to a standard US keyboard map.
 .RE
 
+.PP
+\fBBenchmarking\fR
+.RS
+When started with \fB\-\-benchmark\fR, Caprice32 measures Z80 T-states (wait states included, as on real hardware) and is driven by the emulated program through OUT instructions to three otherwise-inert I/O ports. The command is selected by the port; the written value is ignored:
+.br
+  - \fB&FED0\fR (START): capture the baseline T-state count.
+.br
+  - \fB&FED1\fR (STOP): print the elapsed T-states (current minus baseline) as a single integer to stdout and quit the emulator.
+.br
+  - \fB&FED2\fR (LAP): print a partial result to stderr and keep running.
+.PP
+A human-readable summary (microseconds and frame count) is written to stderr, so stdout carries only the integer and can be captured directly, e.g. \fBC=$(cap32 --benchmark engine.sna)\fR. If STOP is reached without a prior START, the count is measured from boot.
+.PP
+The measured delta includes a small, constant marker overhead, so compare versions instrumented with the same markers. Each LAP between START and STOP adds its own cycles to the final total. To exclude the 50 Hz interrupt from the count, wrap the measured region in \fBDI\fR ... \fBEI\fR. These ports are inert on real CPC hardware (the Multiface 2 only answers &FEE8/&FEEA, and only when fitted), so an instrumented snapshot still runs harmlessly elsewhere. Ready-to-use assembler macros and BASIC examples are provided in \fBdoc/z80_bench.md\fR.
+.RE
+
 \" Missing sections to add:
 \" Multiface 2 invocation
 \" Memory tool usage
@@ -114,6 +130,9 @@ If the mapping file is not defined or not found, Caprice32 will default to a sta
 .TP
 \fB\-a\fR, \fB\-\-autocmd\fR=\fICOMMAND\fR
 pass command to execute to the emulator. The option can be repeated to pass multiple commands. For example: cap32 -a 'print "Hello"' -a 'print "World"'
+.TP
+\fB\-b\fR, \fB\-\-benchmark\fR
+measure the number of Z80 T-states executed between the START and STOP markers, print that count as a single integer to stdout and exit. Runs headless at full speed. See the \fBBenchmarking\fR section.
 .TP
 \fB\-c\fR, \fB\-\-cfg_file\fR=\fIFILE\fR
 use FILE as the emulator configuration file.
@@ -144,6 +163,11 @@ be talkative about what the emulator is doing (mostly for debug builds)
 cap32 ./disk/sorcery.dsk ./trail.dsk
 .RS
 Launches cap32, loads the content of ./disk/sorcery.dsk in the drive A slot, and ./trail.dsk in the drive B slot.
+.RE
+.PP
+cap32 --benchmark ./engine.sna
+.RS
+Runs engine.sna headless and prints to stdout the number of Z80 T-states executed between its START (OUT &FED0) and STOP (OUT &FED1) markers.
 .SH BUGS
 CPC6128+ emulation is incomplete: vectored & DMA interrupts, analog joysticks and 8 bit printer are not emulated.
 .PP

--- a/doc/z80_bench.md
+++ b/doc/z80_bench.md
@@ -1,0 +1,131 @@
+# Z80 benchmarking with `cap32 --benchmark`
+
+This build of Caprice32 can measure the exact number of **Z80 T-states** (CPU clock
+cycles, with the Gate Array wait states included, just like on real hardware) executed by
+a program running inside the emulator. It is meant for comparing optimisation versions of
+a CPC routine in a **deterministic, reproducible, scriptable** way: the same snapshot
+always yields the same number, independent of the host machine and its load.
+
+```sh
+cap32 --benchmark engine.sna        # prints the T-state count to stdout, then exits
+```
+
+## How it works
+
+`--benchmark` runs the emulator **headless at full speed** and counts T-states. The
+emulated program tells the emulator where the measured region starts and ends by writing
+to three I/O ports with `OUT`. The **command is the port** — the value written is ignored:
+
+| Port     | Command | Effect                                                              |
+|----------|---------|--------------------------------------------------------------------|
+| `&FED0`  | START   | Capture the baseline T-state count.                                |
+| `&FED1`  | STOP    | Print `current - baseline` (a single integer) to stdout and quit. |
+| `&FED2`  | LAP     | Print a partial result to stderr and **keep running**.            |
+
+- **stdout** carries only the integer, so it can be captured directly:
+  `C=$(cap32 --benchmark engine.sna)`.
+- **stderr** gets a human-readable summary, e.g.
+  `[bench] 4180676 T-states = 1045169.0 us (52.26 frames @50Hz)`.
+- If STOP is reached without a prior START, the count is measured from boot.
+
+These three ports are **inert on real CPC hardware** (the Multiface 2 only answers `&FEE8`
+/ `&FEEA`, and only when fitted), so a snapshot instrumented with these markers also runs
+harmlessly on a real machine or an unpatched emulator — the markers simply do nothing
+there.
+
+## Z80: assembler macros
+
+Use **inline** markers, not `CALL`/`RET` subroutines: a `CALL`+`RET` would add its own
+cycles to the measured region.
+
+```z80
+;; z80_bench.asm  --  benchmark markers for caprice32 --benchmark
+;; Syntax: RASM / Maxam. For other assemblers, inline the two instructions of each macro.
+
+macro MEASURE_START
+    ld bc,&FED0 : out (c),c        ;; capture baseline
+mend
+
+macro MEASURE_STOP
+    ld bc,&FED1 : out (c),c        ;; print T-states to stdout and exit the emulator
+mend
+
+macro MEASURE_LAP
+    ld bc,&FED2 : out (c),c        ;; print a partial result to stderr, keep running
+mend
+```
+
+### Example
+
+```z80
+    di                  ; (optional) exclude the 50 Hz interrupt from the count
+    MEASURE_START
+    call draw_1000_lines ; the engine code under test
+    MEASURE_STOP
+    ei                  ; never reached: STOP quits the emulator
+```
+
+Build a `.sna` whose program counter sits at this code (or whose boot leads to it), then:
+
+```sh
+cyc_v1=$(cap32 --benchmark engine_v1.sna)
+cyc_v2=$(cap32 --benchmark engine_v2.sna)
+echo "v1=$cyc_v1  v2=$cyc_v2  saved=$((cyc_v1 - cyc_v2)) T-states"
+```
+
+### Multiple checkpoints with LAP
+
+`MEASURE_LAP` reports progress without stopping. The partial counts go to stderr; the
+final STOP still prints the full total to stdout.
+
+```z80
+    MEASURE_START
+    call draw_top_half
+    MEASURE_LAP          ; stderr: [bench] lap <n> T-states
+    call draw_bottom_half
+    MEASURE_STOP         ; stdout: full total
+```
+
+## BASIC: measuring a loop
+
+The same ports work from BASIC, which is handy for a quick check without an assembler
+(`OUT port,value` — the value is irrelevant, use `0`). Drive it with `--autocmd` so the
+emulator types and runs the line automatically:
+
+```sh
+# Measure a 1000-iteration empty FOR/NEXT loop:
+cap32 --benchmark --autocmd 'OUT &FED0,0:FOR I=1 TO 1000:NEXT:OUT &FED1,0'
+# stdout -> e.g. 4180676   (interpreter overhead included; BASIC is slow)
+```
+
+You can wrap any BASIC fragment the same way:
+
+```sh
+cap32 --benchmark --autocmd 'OUT &FED0,0:CALL &8000:OUT &FED1,0'   # time a RSX / machine-code call
+cap32 --benchmark --autocmd 'OUT &FED0,0:PLOT 0,0:DRAW 639,399:OUT &FED1,0'
+```
+
+Doubling the work roughly doubles the count, which is the easy sanity check that the
+measurement tracks real work:
+
+```sh
+for n in 1000 2000 4000; do
+  echo "$n: $(cap32 --benchmark --autocmd "OUT &FED0,0:FOR I=1 TO $n:NEXT:OUT &FED1,0")"
+done
+```
+
+## Notes and caveats
+
+- **Constant marker overhead.** The measured delta includes a small, *constant* overhead
+  from the markers themselves (part of the START/STOP `OUT` plus the `ld bc,nn` setup). It
+  cancels out when you compare two versions instrumented the same way — always compare
+  like with like; don't read the absolute number as the pure cost of your routine.
+- **Interrupts.** The 50 Hz interrupt service routine **is counted** if interrupts are
+  enabled. Wrap the region in `DI` … `EI` to measure pure compute cost, or leave them on
+  to measure the routine exactly as it runs in production.
+- **LAP adds cycles.** Each `MEASURE_LAP` between START and STOP adds its own cycles to the
+  final STOP total (unlike STOP, the emulator keeps running after a LAP).
+- **No watchdog.** If STOP is never reached (a buggy snapshot), the emulator runs forever —
+  wrap automated runs in a timeout, e.g. `timeout 40 cap32 --benchmark engine.sna`.
+- **Determinism.** A given `.sna` produces the same count on every run and on every host.
+- **T-state to time.** 1 T-state = 0.25 µs (4 MHz). One 50 Hz CPC frame is 80000 T-states.

--- a/src/argparse.cpp
+++ b/src/argparse.cpp
@@ -16,6 +16,7 @@
 const struct option long_options[] =
 {
    {"autocmd",  required_argument, nullptr, 'a'},
+   {"benchmark", no_argument, nullptr, 'b'},
    {"cfg_file", required_argument, nullptr, 'c'},
    {"inject", required_argument, nullptr, 'i'},
    {"offset", required_argument, nullptr, 'o'},
@@ -36,6 +37,7 @@ void usage(std::ostream &os, char *progPath, int errcode)
    os << "Usage: " << progname << " [options] <slotfile(s)>\n";
    os << "\nSupported options are:\n";
    os << "   -a/--autocmd=<command>: execute command as soon as the emulator starts.\n";
+   os << "   -b/--benchmark:         measure Z80 T-states between the START (OUT &FED0) and STOP (OUT &FED1) markers, print the count to stdout and exit. Runs headless at full speed.\n";
    os << "   -c/--cfg_file=<file>:   use <file> as the emulator configuration file instead of the default.\n";
    os << "   -h/--help:              shows this help\n";
    os << "   -i/--inject=<file>:     inject a binary in memory after the CPC startup finishes\n";
@@ -102,7 +104,7 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
 
    optind = 0; // To please test framework, when this function is called multiple times !
    while(true) {
-      c = getopt_long (argc, argv, "a:c:hi:o:O:s:vV",
+      c = getopt_long (argc, argv, "a:bc:hi:o:O:s:vV",
                        long_options, &option_index);
       // Logs before processing of the -v will not be visible.
       LOG_DEBUG("Next option: " << c << "(" << static_cast<char>(c) << ")");
@@ -117,6 +119,10 @@ void parseArguments(int argc, char **argv, std::vector<std::string>& slot_list, 
             LOG_VERBOSE("Append to autocmd: " << optarg);
             args.autocmd += replaceCap32Keys(optarg);
             args.autocmd += "\n";
+            break;
+
+         case 'b':
+            args.benchmark = true;
             break;
 
          case 'c':

--- a/src/argparse.h
+++ b/src/argparse.h
@@ -12,9 +12,10 @@ class CapriceArgs
       std::string autocmd;
       std::string cfgFilePath;
       std::string binFile;
-      size_t binOffset;
+      size_t binOffset = 0x6000; // default injection offset, as documented in usage()
       std::map<std::string, std::map<std::string, std::string>> cfgOverrides;
       std::string symFilePath;
+      bool benchmark = false; // --benchmark: measure Z80 T-states and exit on STOP marker
 };
 
 std::string replaceCap32Keys(std::string command);

--- a/src/cap32.cpp
+++ b/src/cap32.cpp
@@ -102,6 +102,12 @@ std::string lastSavedSnapshot;
 
 dword dwBreakPoint, dwTrace, dwMF2ExitAddr;
 dword dwMF2Flags = 0;
+
+// Benchmark mode (--benchmark): monotonic Z80 T-state counter and markers.
+// Driven from the Amstrad code via OUT to ports &FED0 (start) / &FED1 (stop) / &FED2 (lap).
+uint64_t g_bench_tstates = 0; // monotonic T-state counter (wait states included)
+uint64_t g_bench_start   = 0; // baseline captured on START (0 = since boot)
+bool     g_bench_mode    = false; // set by --benchmark
 std::unique_ptr<byte[]> pbSndBuffer;
 byte *pbGPBuffer = nullptr;
 byte *pbSndBufferEnd = nullptr;
@@ -489,6 +495,29 @@ byte z80_IN_handler (reg_pair port)
 void z80_OUT_handler (reg_pair port, byte val)
 {
    LOG_DEBUG("OUT on port " << std::hex << static_cast<int>(port.w.l) << ", val=" << static_cast<int>(val) << std::dec);
+   // Benchmark markers: ports &FED0/&FED1/&FED2 are inert on real CPC hardware (the MF2
+   // only responds to &FEE8/&FEEA, and only when present). Intercepted here, before any
+   // peripheral decoding, so they never reach the hardware. The command is the port, not
+   // the written value. The measured delta includes a small, constant marker overhead.
+   if (g_bench_mode && port.b.h == 0xfe) {
+      switch (port.b.l) {
+         case 0xd0: // START: capture baseline
+            g_bench_start = g_bench_tstates;
+            return;
+         case 0xd2: // LAP: partial result on stderr, keep running
+            fprintf(stderr, "[bench] lap %llu T-states\n",
+                    static_cast<unsigned long long>(g_bench_tstates - g_bench_start));
+            return;
+         case 0xd1: { // STOP: print T-states delta and quit
+            uint64_t delta = g_bench_tstates - g_bench_start;
+            printf("%llu\n", static_cast<unsigned long long>(delta)); // stdout: raw integer
+            fflush(stdout);
+            fprintf(stderr, "[bench] %llu T-states = %.1f us (%.2f frames @50Hz)\n",
+                    static_cast<unsigned long long>(delta), delta / 4.0, delta / 80000.0);
+            cleanExit(0, false); // clean teardown, no "unsaved" prompt
+         }
+      }
+   }
    // Amstrad Magnum Phazer
    if ((port.b.h == 0xfb) && (port.b.l == 0xfe)) {
      // When the phazer is not pressed, the CRTC is constantly refreshing R16 & R17:
@@ -1773,7 +1802,7 @@ std::string getConfigurationFilename(bool forWrite)
     if (!p.first) continue;
     std::string s = std::string(p.first) + p.second;
     if (access(s.c_str(), mode) == 0) {
-      std::cout << "Using configuration file" << (forWrite ? " to save" : "") << ": " << s << std::endl;
+      (args.benchmark ? std::cerr : std::cout) << "Using configuration file" << (forWrite ? " to save" : "") << ": " << s << std::endl;
       // Dirty hack for MacOS Bundle to work: change dir to the bin dir
       // cap32.cfg is edited to have relative paths from the bin dir
       if (p.second == "/../Resources/cap32.cfg") {
@@ -1783,7 +1812,7 @@ std::string getConfigurationFilename(bool forWrite)
     }
   }
 
-  std::cout << "No valid configuration file found, using empty config." << std::endl;
+  (args.benchmark ? std::cerr : std::cout) << "No valid configuration file found, using empty config." << std::endl;
   return "";
 }
 
@@ -2735,6 +2764,15 @@ int cap32_main (int argc, char **argv)
    }
    parseArguments(argc, argv, slot_list, args);
 
+   if (args.benchmark) {
+      // Force a reliable headless setup for automated benchmarking (overwrite=1, so it
+      // wins over the environment in CI). SDL_setenv is cross-platform; setenv() is not
+      // available on Windows, which caprice32 supports.
+      SDL_setenv("SDL_VIDEODRIVER",   "dummy",    1);
+      SDL_setenv("SDL_AUDIODRIVER",   "dummy",    1);
+      SDL_setenv("SDL_RENDER_DRIVER", "software", 1); // "Direct" plugin uses SDL_CreateWindowAndRenderer
+   }
+
    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER | SDL_INIT_NOPARACHUTE) < 0) { // initialize SDL
       fprintf(stderr, "SDL_Init() failed: %s\n", SDL_GetError());
       exit(-1);
@@ -2750,6 +2788,18 @@ int cap32_main (int argc, char **argv)
    #endif
 
    loadConfiguration(CPC, getConfigurationFilename()); // retrieve the emulator configuration
+
+   if (args.benchmark) {
+      // Override config for benchmarking: run headless at full speed, no audio, no pausing.
+      g_bench_mode    = true;
+      g_bench_tstates = 0;
+      g_bench_start   = 0;
+      CPC.limit_speed = 0;                  // run as fast as possible (no real-time throttle)
+      CPC.snd_enabled = 0;                  // skip PSG synthesis in z80_wait_states
+      CPC.auto_pause  = 0;                  // never pause when the window loses focus
+      CPC.scr_style   = DEFAULT_VIDEO_PLUGIN; // software "Direct" plugin, avoids needing a GL context
+   }
+
    if (CPC.printer) {
       if (!printer_start()) { // start capturing printer output, if enabled
          CPC.printer = 0;

--- a/src/log.h
+++ b/src/log.h
@@ -10,10 +10,12 @@ extern bool log_verbose;
 #define LOG_ERROR(message) LOG_TO(std::cerr, "ERROR  ", message)
 #define LOG_WARNING(message) LOG_TO(std::cerr, "WARNING", message)
 #define LOG_INFO(message) LOG_TO(std::cerr, "INFO   ", message)
-#define LOG_VERBOSE(message) if(log_verbose) { LOG_TO(std::cout, "VERBOSE", message) }
+// Diagnostics go to stderr so that stdout stays clean for tool-friendly output
+// (e.g. the single integer printed by --benchmark, regardless of -v / arg order).
+#define LOG_VERBOSE(message) if(log_verbose) { LOG_TO(std::cerr, "VERBOSE", message) }
 
 #ifdef DEBUG
-#define LOG_DEBUG(message) if(log_verbose) { LOG_TO(std::cout, "DEBUG  ", message) }
+#define LOG_DEBUG(message) if(log_verbose) { LOG_TO(std::cerr, "DEBUG  ", message) }
 #else
 #define LOG_DEBUG(message)
 #endif

--- a/src/z80.cpp
+++ b/src/z80.cpp
@@ -44,6 +44,8 @@ extern t_PSG PSG;
 extern t_VDU VDU;
 extern dword dwMF2Flags;
 extern dword dwMF2ExitAddr;
+extern uint64_t g_bench_tstates; // benchmark T-state counter (see cap32.cpp)
+extern bool g_bench_mode;
 
 extern int iTapeCycleCount;
 
@@ -407,6 +409,7 @@ void z80_write_mem(word addr, byte val) {
          } \
       } \
       CPC.cycle_count -= iCycleCount; \
+      if (g_bench_mode) g_bench_tstates += iCycleCount; /* benchmark: coste ~0 fuera de bench */ \
    } \
 }
 

--- a/test/argparse.cpp
+++ b/test/argparse.cpp
@@ -100,3 +100,38 @@ TEST(argParseTest, replaceCap32KeysRepeatedKeywords)
 
   ASSERT_EQ(expected, replaceCap32Keys(command));
 }
+
+TEST(argParseTest, benchmarkFlagDefaultsFalse)
+{
+   const char *argv[] = {"./cap32", "./foo.sna"};
+   CapriceArgs args;
+   std::vector<std::string> slot_list;
+
+   parseArguments(2, const_cast<char **>(argv), slot_list, args);
+
+   ASSERT_FALSE(args.benchmark);
+}
+
+TEST(argParseTest, benchmarkFlagLong)
+{
+   const char *argv[] = {"./cap32", "--benchmark", "./foo.sna"};
+   CapriceArgs args;
+   std::vector<std::string> slot_list;
+
+   parseArguments(3, const_cast<char **>(argv), slot_list, args);
+
+   ASSERT_TRUE(args.benchmark);
+   ASSERT_EQ(1, slot_list.size());
+   ASSERT_EQ("./foo.sna", slot_list.at(0));
+}
+
+TEST(argParseTest, benchmarkFlagShort)
+{
+   const char *argv[] = {"./cap32", "-b", "./foo.sna"};
+   CapriceArgs args;
+   std::vector<std::string> slot_list;
+
+   parseArguments(3, const_cast<char **>(argv), slot_list, args);
+
+   ASSERT_TRUE(args.benchmark);
+}


### PR DESCRIPTION
 I built this to compare some versions of CPC assembler routines by measuring their exact Z80 T-state count, deterministically and from scripts. It's been useful on my side, so I'm sending it upstream in case you'd like to  keep it integrated — no worries if it doesn't fit the project.

`cap32 --benchmark engine.sna` runs headless and prints a single integer to stdout. The emulated program marks the measured region with `OUT` to three ports (the value is ignored): **`&FED0` START**, **`&FED1` STOP** (prints to stdout + quits), **`&FED2` LAP** (partial result to stderr, keeps running). Works from Z80 asm and from BASIC via `--autocmd`.

I chose `&FED0/1/2` because they're free and inert on real CPC hardware. If you'd prefer another range; it's a single constant. And to keep stdout clean for the benchmark integer, this PR also routes `LOG_VERBOSE`/`LOG_DEBUG` from stdout to stderr. That's the only behaviour change outside benchmark mode.

Includes the `--benchmark` flag and core counter, docs (`doc/z80_bench.md` + man page), and unit tests. Happy to adjust ports or naming to your preferences.
