### PR TITLE
Fix Orion Prime game

### DIFF
--- a/src/fdc.cpp
+++ b/src/fdc.cpp
@@ -55,7 +55,10 @@ dword dwBytesTransferred = 0;
 #define RES_N     6
 
 #define OVERRUN_TIMEOUT (128*4)
-#define INITIAL_TIMEOUT (OVERRUN_TIMEOUT*4*20)
+// Finding the right value for INITIAL_TIMEOUT is tricky. Orion Prime breaks if using only 4*4*128.
+// It seems to work fine with 16*4*128. There's no obvious issue with taking a large margin here,
+// so taking 80*4*128 for now.
+#define INITIAL_TIMEOUT (OVERRUN_TIMEOUT*80)
 
 void fdc_specify();
 void fdc_drvstat();

--- a/src/fdc.cpp
+++ b/src/fdc.cpp
@@ -55,7 +55,7 @@ dword dwBytesTransferred = 0;
 #define RES_N     6
 
 #define OVERRUN_TIMEOUT (128*4)
-#define INITIAL_TIMEOUT (OVERRUN_TIMEOUT*4)
+#define INITIAL_TIMEOUT (OVERRUN_TIMEOUT*4*20)
 
 void fdc_specify();
 void fdc_drvstat();


### PR DESCRIPTION
Details: TBD, but they are related to short timeout value. You can play with different timeouts to find the optimal one

<img width="757" height="584" alt="image" src="https://github.com/user-attachments/assets/45207c98-82c0-4548-be64-83a7667a5601" />
